### PR TITLE
feat: 행사 스냅샷 / 상세 html의 image -> 서버에 저장 

### DIFF
--- a/hangsha/batch/src/main/kotlin/com/team1/hangsha/batch/BatchApplication.kt
+++ b/hangsha/batch/src/main/kotlin/com/team1/hangsha/batch/BatchApplication.kt
@@ -3,6 +3,8 @@ package com.team1.hangsha.batch
 import com.team1.hangsha.config.DatabaseConfig
 import com.team1.hangsha.config.TestValueLogger
 import com.team1.hangsha.com.team1.hangsha.config.JacksonConfig
+import com.team1.hangsha.common.upload.OciUploadService
+import com.team1.hangsha.config.OciConfig
 import com.team1.hangsha.event.service.EventSyncService
 import org.springframework.boot.WebApplicationType
 import org.springframework.boot.autoconfigure.SpringBootApplication
@@ -15,6 +17,8 @@ import org.springframework.context.annotation.Import
     JacksonConfig::class,
     EventSyncService::class,
     TestValueLogger::class,
+    OciConfig::class,
+    OciUploadService::class,
 ) // for explicit bean import
 class BatchApplication
 

--- a/hangsha/batch/src/main/kotlin/com/team1/hangsha/batch/crawler/ExtraSnuCrawler.kt
+++ b/hangsha/batch/src/main/kotlin/com/team1/hangsha/batch/crawler/ExtraSnuCrawler.kt
@@ -13,6 +13,7 @@ import org.jsoup.Jsoup
 import org.jsoup.nodes.Element
 import java.util.concurrent.TimeUnit
 import com.team1.hangsha.common.upload.OciUploadService
+import org.jsoup.parser.Parser
 
 class ExtraSnuCrawler(
     private val baseUrl: String = "https://extra.snu.ac.kr",
@@ -71,6 +72,7 @@ class ExtraSnuCrawler(
      */
     fun enrichDetails(
         events: List<ProgramEvent>,
+        ociUploadService: OciUploadService,
         shouldFetch: (ProgramEvent) -> Boolean = { true }
     ): List<ProgramEvent> {
         return events.map { e ->
@@ -80,13 +82,13 @@ class ExtraSnuCrawler(
 
             val html1 = fetchDetailPageByPlaywright(dataSeq) ?: return@map e
             var sessions = parseDetailSessions(html1)
-            var mainHtml = parseMainContentHtml(html1)
+            var mainHtml = parseMainContentHtml(html1, ociUploadService)
 
             if (sessions.isEmpty()) {
                 val html2 = fetchDetailPageByPlaywright(dataSeq)
                 if (html2 != null) {
                     sessions = parseDetailSessions(html2)
-                    mainHtml = parseMainContentHtml(html2)
+                    mainHtml = parseMainContentHtml(html2, ociUploadService)
                 }
             }
 
@@ -337,15 +339,13 @@ class ExtraSnuCrawler(
 
     /**
      * ✅ "프로그램 주요내용" 섹션의 td_box HTML을 "그대로" 저장하되,
-     * - img, a 태그는 제거
      *
      * 반환값은 td_box의 innerHTML.
      * 없으면 null.
      */
-    private fun parseMainContentHtml(html: String): String? {
+    private fun parseMainContentHtml(html: String, ociUploadService: OciUploadService): String? {
         val doc = Jsoup.parse(html, baseUrl)
 
-        // cont_box 중에서 cont_tit == "프로그램 주요내용" 인 박스 찾기
         val box = doc.select("div.cont_box")
             .firstOrNull {
                 it.selectFirst("p.cont_tit")?.text()?.normalize() == "프로그램 주요내용"
@@ -353,14 +353,54 @@ class ExtraSnuCrawler(
 
         val tdBox = box.selectFirst("div.td_box") ?: return null
 
-        // img, a 제거
-        tdBox.select("img").remove()
-        tdBox.select("a").remove()
+        val cookieHeader = buildCookieHeader()
 
-        // 혹시 script/style 섞이면 제거 (안전)
+        tdBox.select("img").forEach { img ->
+            val rawSrc = img.absUrl("src").ifBlank {
+                val decoded = Parser.unescapeEntities(img.attr("src"), false)
+                when {
+                    decoded.startsWith("http://") || decoded.startsWith("https://") -> decoded
+                    decoded.startsWith("/") -> "$baseUrl$decoded"
+                    else -> "$baseUrl/$decoded"
+                }
+            }
+
+            if (rawSrc.isBlank()) {
+                img.remove()
+                return@forEach
+            }
+
+            val downloaded = runCatching {
+                downloadImage(rawSrc, cookieHeader)
+            }.getOrNull()
+
+            if (downloaded == null) {
+                img.remove()
+                return@forEach
+            }
+
+            val uploadedUrl = runCatching {
+                ociUploadService.uploadBytesIfAbsent(
+                    prefix = "events/detail",
+                    originalFilename = null,
+                    bytes = downloaded.bytes,
+                    contentType = downloaded.contentType,
+                )
+            }.getOrNull()
+
+            if (uploadedUrl == null) {
+                img.remove()
+                return@forEach
+            }
+
+            img.attr("src", uploadedUrl)
+            img.removeAttr("onclick")
+            img.removeAttr("usemap")
+        }
+
+        tdBox.select("a").forEach { it.unwrap() }
         tdBox.select("script, style").remove()
 
-        // 빈 p 같은 거 정리(선택)
         tdBox.select("p").forEach { p ->
             if (p.text().normalize().isBlank() && p.select("br").isEmpty() && p.childrenSize() == 0) {
                 p.remove()
@@ -371,6 +411,10 @@ class ExtraSnuCrawler(
         return out.ifBlank { null }
     }
 
+    // ---------------------------
+    // helpers
+    // ---------------------------
+
     private fun tdAfterThContains(tr: Element, label: String): String? {
         val th = tr.select("th")
             .firstOrNull { it.text().normalize().contains(label) }
@@ -379,15 +423,6 @@ class ExtraSnuCrawler(
         val td = th.nextElementSibling() ?: return null
         return td.text().normalize().takeIf { it.isNotBlank() }
     }
-
-    // ---------------------------
-    // helpers
-    // ---------------------------
-
-    private fun signatureOf(events: List<ProgramEvent>): String =
-        events.take(5).joinToString("|") { e ->
-            "${e.dataSeq}:${e.title}:${e.status}:${e.applyStart}:${e.applyEnd}"
-        }
 
     private fun String.toIntOrNullSafe(): Int? {
         val cleaned = this.replace(",", "").trim()

--- a/hangsha/batch/src/main/kotlin/com/team1/hangsha/batch/crawler/ExtraSnuCrawler.kt
+++ b/hangsha/batch/src/main/kotlin/com/team1/hangsha/batch/crawler/ExtraSnuCrawler.kt
@@ -12,6 +12,7 @@ import okhttp3.Request
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Element
 import java.util.concurrent.TimeUnit
+import com.team1.hangsha.common.upload.OciUploadService
 
 class ExtraSnuCrawler(
     private val baseUrl: String = "https://extra.snu.ac.kr",
@@ -483,4 +484,106 @@ class ExtraSnuCrawler(
         val html = fetchListPage(pageNo) ?: return emptyList()
         return parseListHtml(html)
     }
+
+    fun uploadEventImages(
+        events: List<ProgramEvent>,
+        ociUploadService: OciUploadService,
+    ): List<ProgramEvent> {
+        val cookieHeader = buildCookieHeader()
+
+        if (cookieHeader.isBlank()) {
+            if (debug) println("[IMG] no playwright cookies; skip image upload")
+            return events
+        }
+
+        return events.map { event ->
+            val rawUrl = event.imageUrl?.trim()
+            if (rawUrl.isNullOrBlank()) return@map event
+
+            val downloaded = runCatching {
+                downloadImage(rawUrl, cookieHeader)
+            }.onFailure {
+                if (debug) println("[IMG] download fail dataSeq=${event.dataSeq} msg=${it.message}")
+            }.getOrNull()
+
+            if (downloaded == null) {
+                return@map event.copy(imageUrl = null)
+            }
+
+            val uploadedUrl = runCatching {
+                ociUploadService.uploadBytesIfAbsent(
+                    prefix = "events",
+                    originalFilename = "event-${event.dataSeq ?: "unknown"}",
+                    bytes = downloaded.bytes,
+                    contentType = downloaded.contentType,
+                )
+            }.onFailure {
+                if (debug) println("[IMG] upload fail dataSeq=${event.dataSeq} msg=${it.message}")
+            }.getOrNull()
+
+            if (uploadedUrl == null) {
+                event.copy(imageUrl = null)
+            } else {
+                if (debug) println("[IMG] uploaded dataSeq=${event.dataSeq} -> $uploadedUrl")
+                event.copy(imageUrl = uploadedUrl)
+            }
+        }
+    }
+
+    private fun buildCookieHeader(): String {
+        return pwContext.cookies()
+            .joinToString("; ") { "${it.name}=${it.value}" }
+    }
+
+    private fun downloadImage(rawUrl: String, cookieHeader: String): DownloadedImage? {
+        val absoluteUrl = when {
+            rawUrl.startsWith("http://") || rawUrl.startsWith("https://") -> rawUrl
+            rawUrl.startsWith("/") -> "$baseUrl$rawUrl"
+            else -> "$baseUrl/$rawUrl"
+        }
+
+        val req = Request.Builder()
+            .url(absoluteUrl)
+            .get()
+            .header("Referer", "$baseUrl$listPath")
+            .header("User-Agent", userAgent)
+            .header("Accept", "image/avif,image/webp,image/apng,image/*,*/*;q=0.8")
+            .header("Cookie", cookieHeader)
+            .build()
+
+        if (debug) println("[IMG] GET $absoluteUrl")
+
+        client.newCall(req).execute().use { resp ->
+            if (!resp.isSuccessful) {
+                if (debug) println("[IMG] FAIL code=${resp.code} url=$absoluteUrl")
+                return null
+            }
+
+            val body = resp.body ?: return null
+            val bytes = body.bytes()
+            if (bytes.isEmpty()) return null
+
+            val contentType = body.contentType()?.toString() ?: "application/octet-stream"
+            val extension = when (contentType.lowercase()) {
+                "image/jpeg", "image/jpg" -> "jpg"
+                "image/png" -> "png"
+                "image/gif" -> "gif"
+                "image/webp" -> "webp"
+                "image/bmp" -> "bmp"
+                else -> "bin"
+            }
+
+            return DownloadedImage(
+                bytes = bytes,
+                contentType = contentType,
+                extension = extension,
+            )
+        }
+    }
+
+    private data class DownloadedImage(
+        val bytes: ByteArray,
+        val contentType: String,
+        val extension: String,
+    )
 }

--- a/hangsha/batch/src/main/kotlin/com/team1/hangsha/batch/job/ExtraSnuSyncRunner.kt
+++ b/hangsha/batch/src/main/kotlin/com/team1/hangsha/batch/job/ExtraSnuSyncRunner.kt
@@ -3,6 +3,7 @@ package com.team1.hangsha.batch.job
 import com.team1.hangsha.batch.crawler.DetailSession
 import com.team1.hangsha.batch.crawler.ExtraSnuCrawler
 import com.team1.hangsha.batch.crawler.ProgramEvent
+import com.team1.hangsha.common.upload.OciUploadService
 import com.team1.hangsha.event.dto.core.CrawledDetailSession
 import com.team1.hangsha.event.dto.core.CrawledProgramEvent
 import com.team1.hangsha.event.service.EventSyncService
@@ -14,6 +15,7 @@ import kotlin.system.exitProcess
 @Component
 class ExtraSnuSyncRunner(
     private val eventSyncService: EventSyncService,
+    private val ociUploadService: OciUploadService,
 ) : ApplicationRunner {
 
     override fun run(args: ApplicationArguments) {
@@ -46,7 +48,13 @@ class ExtraSnuSyncRunner(
                     crawler.enrichDetails(baseEvents) // { e -> e.status != "모집마감" } // @TODO: 위의 0001, 0002, ... 와 같이 매직 넘버라, ENUM화?
                 }
 
-                val result = eventSyncService.sync(events.map { it.toCrawledProgramEvent() })
+                val eventsWithUploadedImages = if (!opt.withDetails) {
+                    events
+                } else {
+                    crawler.uploadEventImages(events, ociUploadService)
+                }
+
+                val result = eventSyncService.sync(eventsWithUploadedImages.map { it.toCrawledProgramEvent() })
 
                 totalUpserted += result.upserted
                 totalCrawled += result.total

--- a/hangsha/batch/src/main/kotlin/com/team1/hangsha/batch/job/ExtraSnuSyncRunner.kt
+++ b/hangsha/batch/src/main/kotlin/com/team1/hangsha/batch/job/ExtraSnuSyncRunner.kt
@@ -45,7 +45,7 @@ class ExtraSnuSyncRunner(
                 val events = if (!opt.withDetails) {
                     baseEvents
                 } else {
-                    crawler.enrichDetails(baseEvents) // { e -> e.status != "모집마감" } // @TODO: 위의 0001, 0002, ... 와 같이 매직 넘버라, ENUM화?
+                    crawler.enrichDetails(baseEvents, ociUploadService) // { e -> e.status != "모집마감" } // @TODO: 위의 0001, 0002, ... 와 같이 매직 넘버라, ENUM화?
                 }
 
                 val eventsWithUploadedImages = if (!opt.withDetails) {

--- a/hangsha/common/src/main/kotlin/com/team1/hangsha/common/upload/OciUploadService.kt
+++ b/hangsha/common/src/main/kotlin/com/team1/hangsha/common/upload/OciUploadService.kt
@@ -8,6 +8,9 @@ import org.springframework.web.multipart.MultipartFile
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 import java.util.UUID
+import com.oracle.bmc.objectstorage.requests.HeadObjectRequest
+import java.io.ByteArrayInputStream
+import java.security.MessageDigest
 
 @Service
 class OciUploadService(
@@ -48,5 +51,117 @@ class OciUploadService(
         val encodedObjectName = URLEncoder.encode(objectName, StandardCharsets.UTF_8)
             .replace("+", "%20")
         return "https://objectstorage.$region.oraclecloud.com/n/$namespace/b/$bucket/o/$encodedObjectName"
+    }
+
+    fun uploadBytesIfAbsent(
+        prefix: String?,
+        originalFilename: String?,
+        bytes: ByteArray,
+        contentType: String = "application/octet-stream",
+    ): String {
+        require(bytes.isNotEmpty()) { "empty bytes" }
+
+        val ext = extractExtension(originalFilename, contentType, bytes)
+        val sha256 = sha256Hex(bytes)
+        val objectName = buildObjectName(prefix, "$sha256.$ext")
+
+        if (!exists(objectName)) {
+            ByteArrayInputStream(bytes).use { input ->
+                val request = PutObjectRequest.builder()
+                    .namespaceName(namespace)
+                    .bucketName(bucket)
+                    .objectName(objectName)
+                    .contentLength(bytes.size.toLong())
+                    .contentType(contentType)
+                    .putObjectBody(input)
+                    .build()
+                objectStorage.putObject(request)
+            }
+        }
+
+        return buildPublicUrl(objectName)
+    }
+
+    private fun exists(objectName: String): Boolean {
+        return try {
+            val request = HeadObjectRequest.builder()
+                .namespaceName(namespace)
+                .bucketName(bucket)
+                .objectName(objectName)
+                .build()
+            objectStorage.headObject(request)
+            true
+        } catch (_: Exception) {
+            false
+        }
+    }
+
+    private fun extractExtension(
+        originalFilename: String?,
+        contentType: String,
+        bytes: ByteArray,
+    ): String {
+        val fromName = originalFilename
+            ?.substringAfterLast('.', "")
+            ?.lowercase()
+            ?.takeIf { it.isNotBlank() }
+
+        if (fromName != null && fromName != "bin") return fromName
+
+        detectImageExtension(bytes)?.let { return it }
+
+        return when (contentType.lowercase()) {
+            "image/jpeg", "image/jpg" -> "jpg"
+            "image/png" -> "png"
+            "image/gif" -> "gif"
+            "image/webp" -> "webp"
+            "image/bmp" -> "bmp"
+            else -> "bin"
+        }
+    }
+
+    private fun sha256Hex(bytes: ByteArray): String {
+        val digest = MessageDigest.getInstance("SHA-256").digest(bytes)
+        return digest.joinToString("") { "%02x".format(it) }
+    }
+
+    private fun detectImageExtension(bytes: ByteArray): String? {
+        if (bytes.size >= 2) {
+            if (bytes[0] == 0xFF.toByte() && bytes[1] == 0xD8.toByte()) {
+                return "jpg"
+            }
+        }
+
+        if (bytes.size >= 8) {
+            if (
+                bytes[0] == 0x89.toByte() &&
+                bytes[1] == 0x50.toByte() &&
+                bytes[2] == 0x4E.toByte() &&
+                bytes[3] == 0x47.toByte() &&
+                bytes[4] == 0x0D.toByte() &&
+                bytes[5] == 0x0A.toByte() &&
+                bytes[6] == 0x1A.toByte() &&
+                bytes[7] == 0x0A.toByte()
+            ) {
+                return "png"
+            }
+        }
+
+        if (bytes.size >= 6) {
+            val header = bytes.copyOfRange(0, 6).toString(Charsets.US_ASCII)
+            if (header == "GIF87a" || header == "GIF89a") {
+                return "gif"
+            }
+        }
+
+        if (bytes.size >= 12) {
+            val riff = bytes.copyOfRange(0, 4).toString(Charsets.US_ASCII)
+            val webp = bytes.copyOfRange(8, 12).toString(Charsets.US_ASCII)
+            if (riff == "RIFF" && webp == "WEBP") {
+                return "webp"
+            }
+        }
+
+        return null
     }
 }

--- a/hangsha/src/main/kotlin/com/team1/hangsha/common/upload/OciUploadService.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/common/upload/OciUploadService.kt
@@ -11,6 +11,8 @@ import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 import java.util.UUID
 
+// OciUploadService가 common에도 존재하는데 main에도 존재...?
+
 @Service
 class OciUploadService(
     private val objectStorage: ObjectStorage,


### PR DESCRIPTION
- 비교과 사이트의 img src에 있는 ref는 static URL이 아니라, 

img alt="" onclick="this.src.popupView()" src="/comm/cmfile/download.do?encFileGrpSeq=bb613f815cc830bf86b8e9537de8f928&amp;encFileSeq=83f7b5f40ecf4c7a3d756ec0846aedec"

와 같은 다운로드 endpoint인 경우가 대부분 -> 그래서 당연히 저 링크로 불러오려고 하면 처리가 안 됐음. 

--> 따라서, 크롤러가 이미지를 받고, OCI에 업로드하고, DB에는 OCI public URL 저장하는 방식으로 처리.

- 구현:
1. batch에 OciUploadService 주입 (BatchApplication에 import)
2. ExtraSnuCrawler에 메인 이미지 처리 로직 붙임 (Playwright 세션의 Referer + User-Agent + Cookie 다 붙인 request로 GET -> 받은 bytes를 OCI에 업로드)

- 일단 로컬에서 이미지 OCI에 업로드 되고 + DB에 OCI URL 저장되는 건 확인했는데, 행사 스키마 바꾸면서 데이터 날리고 싹 다시 크롤링 할 거라, develop에 2개 PR merge해서 dev server에서 잘 되는지 확인해보고 싶음 !! 