### PR TITLE
fix: skip events with fallback details to prevent duplicate event keys

### DIFF
--- a/hangsha/common/src/main/kotlin/com/team1/hangsha/event/service/EventSyncService.kt
+++ b/hangsha/common/src/main/kotlin/com/team1/hangsha/event/service/EventSyncService.kt
@@ -53,6 +53,7 @@ class EventSyncService(
             val applyEnd = e.applyEnd?.let { dateEnd(it) }
 
             val sessions = patchSessionTimesFromMainContent(e.detailSessions, e.mainContentHtml)
+            val hasExistingForApplyLink = eventRepository.findByApplyLink(applyLink) != null
 
             data class UnitSpec(
                 val eventStart: LocalDateTime?,
@@ -92,6 +93,12 @@ class EventSyncService(
                     } else {
                         null
                     }
+
+                val isAllDayFallbackPeriod = sessions.isEmpty()
+                if (existing == null && hasExistingForApplyLink && isAllDayFallbackPeriod) {
+                    skipped++
+                    continue
+                }
 
                 val cleanedTags = e.tags
                     .asSequence()


### PR DESCRIPTION
같은 행사가 fallback 처리 때문에 중복으로 들어오는 문제 해결! -> detail을 못 받아오면 그냥 애초에 스킵하도록 함.
(근데 이러면 운이 안 좋으면 크롤링이 안 될 수도 있는 거 아닌가...?! 싶기도 한데 일단... ??)

{
            "id": 245,
            "title": "[5/19,2회차]관악사 부관장님을 이겨라! 테니스 렐리",
            "imageUrl": "https://objectstorage.ap-chuncheon-1.oraclecloud.com/n/ax1dvc8vmenm/b/hangsha-asset-dev/o/events%2Fd2598d6c8cf24f5fc96eb8087f82f42be22a8efdf549d466f5a59d8ecd74f5f0.png",
            "operationMode": "오프라인",
            "statusId": 1,
            "eventTypeId": 39,
            "orgId": 19,
            "applyStart": "2026-04-07T00:00:00",
            "applyEnd": "2026-05-12T23:59:59",
            **"eventStart": "2026-05-19T19:00:00",
            "eventEnd": "2026-05-19T21:00:00",**
            "capacity": 15,
            "applyCount": 0,
            "organization": "관악학생생활관",
            "location": "경영대 옆 테니스 코트",
            "applyLink": "https://extra.snu.ac.kr/ptfol/pgm/view.do?dataSeq=PGM012001708",
            "tags": "[\"#OpenLnL\", \"#LnL\", \"#테니스\", \"#\", \"#관악사\"]",
            "isInterested": null,
            "matchedInterestPriority": null,
            "isBookmarked": null
        },
        {
            "id": 264,
            "title": "[5/19,2회차]관악사 부관장님을 이겨라! 테니스 렐리",
            "imageUrl": "https://objectstorage.ap-chuncheon-1.oraclecloud.com/n/ax1dvc8vmenm/b/hangsha-asset-dev/o/events%2Fd2598d6c8cf24f5fc96eb8087f82f42be22a8efdf549d466f5a59d8ecd74f5f0.png",
            "operationMode": "오프라인",
            "statusId": 1,
            "eventTypeId": 39,
            "orgId": 19,
            "applyStart": "2026-04-07T00:00:00",
            "applyEnd": "2026-05-12T23:59:59",
            **"eventStart": "2026-05-19T00:00:00",
            "eventEnd": "2026-05-19T23:59:59",**
            "capacity": 15,
            "applyCount": 0,
            "organization": "관악학생생활관",
            "location": null,
            "applyLink": "https://extra.snu.ac.kr/ptfol/pgm/view.do?dataSeq=PGM012001708",
            "tags": "[\"#OpenLnL\", \"#LnL\", \"#테니스\", \"#\", \"#관악사\"]",
            "isInterested": null,
            "matchedInterestPriority": null,
            "isBookmarked": null
        },