### PR TITLE
Add JSON dump capability for crawler and admin POST sync endpoint

### DIFF
--- a/hangsha/batch/src/main/kotlin/com/team1/hangsha/batch/job/ExtraSnuSyncRunner.kt
+++ b/hangsha/batch/src/main/kotlin/com/team1/hangsha/batch/job/ExtraSnuSyncRunner.kt
@@ -1,5 +1,6 @@
 package com.team1.hangsha.batch.job
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.team1.hangsha.batch.crawler.DetailSession
 import com.team1.hangsha.batch.crawler.ExtraSnuCrawler
 import com.team1.hangsha.batch.crawler.ProgramEvent
@@ -10,12 +11,15 @@ import com.team1.hangsha.event.service.EventSyncService
 import org.springframework.boot.ApplicationArguments
 import org.springframework.boot.ApplicationRunner
 import org.springframework.stereotype.Component
+import java.nio.file.Files
+import java.nio.file.Path
 import kotlin.system.exitProcess
 
 @Component
 class ExtraSnuSyncRunner(
     private val eventSyncService: EventSyncService,
     private val ociUploadService: OciUploadService,
+    private val objectMapper: ObjectMapper,
 ) : ApplicationRunner {
 
     override fun run(args: ApplicationArguments) {
@@ -26,6 +30,7 @@ class ExtraSnuSyncRunner(
         var totalUpserted = 0
         var totalCrawled = 0
         var totalSkipped = 0
+        val dumpBuffer = mutableListOf<CrawledProgramEvent>()
 
         ExtraSnuCrawler(
             delayMsBetweenPages = opt.delayMs,
@@ -54,18 +59,42 @@ class ExtraSnuSyncRunner(
                     crawler.uploadEventImages(events, ociUploadService)
                 }
 
-                val result = eventSyncService.sync(eventsWithUploadedImages.map { it.toCrawledProgramEvent() })
+                val crawledEvents = eventsWithUploadedImages.map { it.toCrawledProgramEvent() }
+                if (opt.outFile != null) {
+                    dumpBuffer += crawledEvents
+                }
 
+                totalCrawled += crawledEvents.size
+                if (opt.dumpOnly) {
+                    println("Page $page crawled: total=${crawledEvents.size}")
+                    continue
+                }
+
+                val result = eventSyncService.sync(crawledEvents)
                 totalUpserted += result.upserted
-                totalCrawled += result.total
                 totalSkipped += result.skipped
 
                 println("Page $page synced: upserted=${result.upserted}, total=${result.total}, skipped=${result.skipped}")
             }
         }
 
-        println("Synced $totalUpserted rows from $totalCrawled crawled events (skipped=$totalSkipped)")
+        if (opt.outFile != null) {
+            writeDumpFile(opt.outFile, dumpBuffer)
+            println("Saved crawled events to ${opt.outFile} (count=${dumpBuffer.size})")
+        }
+
+        if (opt.dumpOnly) {
+            println("Crawled $totalCrawled rows (dump-only mode)")
+        } else {
+            println("Synced $totalUpserted rows from $totalCrawled crawled events (skipped=$totalSkipped)")
+        }
         exitProcess(0)
+    }
+
+    private fun writeDumpFile(outFile: String, rows: List<CrawledProgramEvent>) {
+        val path = Path.of(outFile).toAbsolutePath().normalize()
+        path.parent?.let { Files.createDirectories(it) }
+        objectMapper.writerWithDefaultPrettyPrinter().writeValue(path.toFile(), rows)
     }
 }
 
@@ -75,6 +104,8 @@ private data class BatchArgs(
     val delayMs: Long = 200,
     val withDetails: Boolean = true,
     val detailDelayMs: Long = 100,
+    val outFile: String? = null,
+    val dumpOnly: Boolean = false,
 ) {
     companion object {
         fun from(args: ApplicationArguments): BatchArgs {
@@ -92,6 +123,8 @@ private data class BatchArgs(
                 delayMs = single("delayMs")?.toLong() ?: 200L,
                 withDetails = withDetails,
                 detailDelayMs = single("detailDelayMs")?.toLong() ?: 100L,
+                outFile = single("outFile"),
+                dumpOnly = args.containsOption("dumpOnly"),
             )
         }
     }

--- a/hangsha/src/main/kotlin/com/team1/hangsha/event/controller/EventSyncController.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/event/controller/EventSyncController.kt
@@ -1,9 +1,11 @@
 package com.team1.hangsha.event.controller
 
+import com.team1.hangsha.event.dto.core.CrawledProgramEvent
 import com.team1.hangsha.event.dto.request.EventPatchRequest
 import com.team1.hangsha.event.repository.EventRepository
 import com.team1.hangsha.event.service.EventSyncService
 import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestBody
@@ -16,6 +18,19 @@ class EventSyncController(
     private val eventSyncService: EventSyncService,
     private val eventRepository: EventRepository,
 ) {
+    @PostMapping("/sync")
+    fun sync(
+        @RequestBody events: List<CrawledProgramEvent>,
+    ): Map<String, Any> {
+        val result = eventSyncService.sync(events)
+        return mapOf(
+            "ok" to true,
+            "total" to result.total,
+            "upserted" to result.upserted,
+            "skipped" to result.skipped,
+        )
+    }
+
     @DeleteMapping("/delete")
     fun deleteAll(): Map<String, Any> {
         val deleted = eventRepository.deleteAllEventsRaw()


### PR DESCRIPTION
### Motivation

- Provide a way to persist crawled events to a JSON file for debugging or offline processing without pushing to the DB.
- Allow running the batch in a dump-only mode to crawl and write output without performing sync operations.
- Expose an admin HTTP endpoint to accept a list of crawled events and trigger the existing sync logic remotely.

### Description

- Extended `ExtraSnuSyncRunner` to accept new batch options `outFile` and `dumpOnly` via `BatchArgs` and to collect crawled `CrawledProgramEvent` rows into a `dumpBuffer`.
- Added `ObjectMapper` injection and a `writeDumpFile` helper that creates parent directories and writes pretty-printed JSON using `objectMapper.writerWithDefaultPrettyPrinter().writeValue(...)`.
- Modified crawl loop to accumulate `crawledEvents`, skip syncing when `dumpOnly` is set, and print different summary messages for dump-only vs sync flows.
- Added `POST /admin/events/sync` in `EventSyncController` to accept `List<CrawledProgramEvent>` and invoke `eventSyncService.sync(...)`, returning `total`, `upserted`, and `skipped` counts.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e23f7d8f2c832f83822283f8f84b33)