### PR TITLE
Add dump-only export for crawler and POST /admin/events/sync endpoint

### DIFF
--- a/hangsha/batch/src/main/kotlin/com/team1/hangsha/batch/job/ExtraSnuSyncRunner.kt
+++ b/hangsha/batch/src/main/kotlin/com/team1/hangsha/batch/job/ExtraSnuSyncRunner.kt
@@ -1,5 +1,6 @@
 package com.team1.hangsha.batch.job
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.team1.hangsha.batch.crawler.DetailSession
 import com.team1.hangsha.batch.crawler.ExtraSnuCrawler
 import com.team1.hangsha.batch.crawler.ProgramEvent
@@ -10,12 +11,15 @@ import com.team1.hangsha.event.service.EventSyncService
 import org.springframework.boot.ApplicationArguments
 import org.springframework.boot.ApplicationRunner
 import org.springframework.stereotype.Component
+import java.nio.file.Files
+import java.nio.file.Path
 import kotlin.system.exitProcess
 
 @Component
 class ExtraSnuSyncRunner(
     private val eventSyncService: EventSyncService,
     private val ociUploadService: OciUploadService,
+    private val objectMapper: ObjectMapper,
 ) : ApplicationRunner {
 
     override fun run(args: ApplicationArguments) {
@@ -26,6 +30,7 @@ class ExtraSnuSyncRunner(
         var totalUpserted = 0
         var totalCrawled = 0
         var totalSkipped = 0
+        val dumpBuffer = mutableListOf<CrawledProgramEvent>()
 
         ExtraSnuCrawler(
             delayMsBetweenPages = opt.delayMs,
@@ -48,24 +53,45 @@ class ExtraSnuSyncRunner(
                     crawler.enrichDetails(baseEvents, ociUploadService) // { e -> e.status != "모집마감" } // @TODO: 위의 0001, 0002, ... 와 같이 매직 넘버라, ENUM화?
                 }
 
-                val eventsWithUploadedImages = if (!opt.withDetails) {
-                    events
-                } else {
-                    crawler.uploadEventImages(events, ociUploadService)
+                // dumpOnly 여부와 상관없이 이미지 업로드는 항상 수행한다.
+                val eventsWithUploadedImages = crawler.uploadEventImages(events, ociUploadService)
+
+                val crawledEvents = eventsWithUploadedImages.map { it.toCrawledProgramEvent() }
+                if (opt.outFile != null) {
+                    dumpBuffer += crawledEvents
                 }
 
-                val result = eventSyncService.sync(eventsWithUploadedImages.map { it.toCrawledProgramEvent() })
+                totalCrawled += crawledEvents.size
+                if (opt.dumpOnly) {
+                    println("Page $page crawled: total=${crawledEvents.size}")
+                    continue
+                }
 
+                val result = eventSyncService.sync(crawledEvents)
                 totalUpserted += result.upserted
-                totalCrawled += result.total
                 totalSkipped += result.skipped
 
                 println("Page $page synced: upserted=${result.upserted}, total=${result.total}, skipped=${result.skipped}")
             }
         }
 
-        println("Synced $totalUpserted rows from $totalCrawled crawled events (skipped=$totalSkipped)")
+        if (opt.outFile != null) {
+            writeDumpFile(opt.outFile, dumpBuffer)
+            println("Saved crawled events to ${opt.outFile} (count=${dumpBuffer.size})")
+        }
+
+        if (opt.dumpOnly) {
+            println("Crawled $totalCrawled rows (dump-only mode)")
+        } else {
+            println("Synced $totalUpserted rows from $totalCrawled crawled events (skipped=$totalSkipped)")
+        }
         exitProcess(0)
+    }
+
+    private fun writeDumpFile(outFile: String, rows: List<CrawledProgramEvent>) {
+        val path = Path.of(outFile).toAbsolutePath().normalize()
+        path.parent?.let { Files.createDirectories(it) }
+        objectMapper.writerWithDefaultPrettyPrinter().writeValue(path.toFile(), rows)
     }
 }
 
@@ -75,6 +101,8 @@ private data class BatchArgs(
     val delayMs: Long = 200,
     val withDetails: Boolean = true,
     val detailDelayMs: Long = 100,
+    val outFile: String? = null,
+    val dumpOnly: Boolean = false,
 ) {
     companion object {
         fun from(args: ApplicationArguments): BatchArgs {
@@ -92,6 +120,8 @@ private data class BatchArgs(
                 delayMs = single("delayMs")?.toLong() ?: 200L,
                 withDetails = withDetails,
                 detailDelayMs = single("detailDelayMs")?.toLong() ?: 100L,
+                outFile = single("outFile"),
+                dumpOnly = args.containsOption("dumpOnly"),
             )
         }
     }

--- a/hangsha/src/main/kotlin/com/team1/hangsha/event/controller/EventSyncController.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/event/controller/EventSyncController.kt
@@ -1,9 +1,11 @@
 package com.team1.hangsha.event.controller
 
+import com.team1.hangsha.event.dto.core.CrawledProgramEvent
 import com.team1.hangsha.event.dto.request.EventPatchRequest
 import com.team1.hangsha.event.repository.EventRepository
 import com.team1.hangsha.event.service.EventSyncService
 import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestBody
@@ -16,6 +18,19 @@ class EventSyncController(
     private val eventSyncService: EventSyncService,
     private val eventRepository: EventRepository,
 ) {
+    @PostMapping("/sync")
+    fun sync(
+        @RequestBody events: List<CrawledProgramEvent>,
+    ): Map<String, Any> {
+        val result = eventSyncService.sync(events)
+        return mapOf(
+            "ok" to true,
+            "total" to result.total,
+            "upserted" to result.upserted,
+            "skipped" to result.skipped,
+        )
+    }
+
     @DeleteMapping("/delete")
     fun deleteAll(): Map<String, Any> {
         val deleted = eventRepository.deleteAllEventsRaw()


### PR DESCRIPTION
### Motivation

- Provide a way to dump crawled events to a JSON file (and run in dump-only mode) without syncing them to the DB.
- Ensure images are uploaded regardless of dump mode so dumped events include final image URLs.
- Add an HTTP admin endpoint to allow syncing a batch of `CrawledProgramEvent` payloads via POST.

### Description

- Enhanced `ExtraSnuSyncRunner` to accept `outFile` and `dumpOnly` options in `BatchArgs` and collect crawled events into a `dumpBuffer`.
- Injected an `ObjectMapper` and added `writeDumpFile` which writes pretty-printed JSON to the configured `outFile` creating parent directories as needed.
- Changed the crawler flow to always call `uploadEventImages`, convert to `CrawledProgramEvent`, track counts, support `dumpOnly` early return, and adjust final logging messages.
- Added a new `POST /admin/events/sync` handler in `EventSyncController` which accepts `List<CrawledProgramEvent>` and delegates to `EventSyncService.sync` returning summary stats.

### Testing

- Ran the test suite with `./gradlew test` and the tests completed successfully.
- Built the project with `./gradlew assemble` and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e23f7d8f2c832f83822283f8f84b33)