### PR TITLE
Add multipart JSON file sync endpoint and permit admin paths in security config

### DIFF
--- a/hangsha/src/main/kotlin/com/team1/hangsha/config/SecurityConfig.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/config/SecurityConfig.kt
@@ -63,9 +63,8 @@ class SecurityConfig(
                         // 주최 기관
                         "/api/v1/category-groups/**",
                         "/api/v1/categories/**",
-                        // @TODO: 자동 크롤링 시 삭제 필요
-                        "/admin/events/sync",
-                        "/admin/events/delete",
+                        // admin
+                        "/admin/**",
                         // 파일 업로드
                         "/static/**",
                         "/api/v1/uploads/oci/**",

--- a/hangsha/src/main/kotlin/com/team1/hangsha/event/controller/EventSyncController.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/event/controller/EventSyncController.kt
@@ -1,27 +1,83 @@
 package com.team1.hangsha.event.controller
 
+import com.fasterxml.jackson.core.JsonToken
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.team1.hangsha.event.dto.core.CrawledProgramEvent
 import com.team1.hangsha.event.dto.request.EventPatchRequest
 import com.team1.hangsha.event.repository.EventRepository
 import com.team1.hangsha.event.service.EventSyncService
+import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.DeleteMapping
-import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.server.ResponseStatusException
+import org.springframework.web.multipart.MultipartFile
 
 @RestController
 @RequestMapping("/admin/events")
 class EventSyncController(
     private val eventSyncService: EventSyncService,
     private val eventRepository: EventRepository,
+    private val objectMapper: ObjectMapper,
 ) {
     @PostMapping("/sync")
     fun sync(
         @RequestBody events: List<CrawledProgramEvent>,
     ): Map<String, Any> {
+        return runSync(events)
+    }
+
+    @PostMapping("/sync", consumes = ["multipart/form-data"])
+    fun syncByFile(
+        @RequestParam("file") file: MultipartFile,
+    ): Map<String, Any> {
+        file.inputStream.use { input ->
+            objectMapper.factory.createParser(input).use { parser ->
+                if (parser.nextToken() != JsonToken.START_ARRAY) {
+                    throw ResponseStatusException(HttpStatus.BAD_REQUEST, "file must be a JSON array")
+                }
+
+                var total = 0
+                var upserted = 0
+                var skipped = 0
+                val buffer = ArrayList<CrawledProgramEvent>(SYNC_BATCH_SIZE)
+
+                while (parser.nextToken() != JsonToken.END_ARRAY) {
+                    val event = objectMapper.readValue(parser, CrawledProgramEvent::class.java)
+                    buffer.add(event)
+
+                    if (buffer.size >= SYNC_BATCH_SIZE) {
+                        val result = eventSyncService.sync(buffer)
+                        total += result.total
+                        upserted += result.upserted
+                        skipped += result.skipped
+                        buffer.clear()
+                    }
+                }
+
+                if (buffer.isNotEmpty()) {
+                    val result = eventSyncService.sync(buffer)
+                    total += result.total
+                    upserted += result.upserted
+                    skipped += result.skipped
+                }
+
+                return mapOf(
+                    "ok" to true,
+                    "total" to total,
+                    "upserted" to upserted,
+                    "skipped" to skipped,
+                )
+            }
+        }
+    }
+
+    private fun runSync(events: List<CrawledProgramEvent>): Map<String, Any> {
         val result = eventSyncService.sync(events)
         return mapOf(
             "ok" to true,
@@ -47,4 +103,8 @@ class EventSyncController(
     fun deleteEvent(
         @PathVariable eventId: Long,
     ): Map<String, Any> = eventSyncService.deleteEvent(eventId)
+
+    companion object {
+        private const val SYNC_BATCH_SIZE = 500
+    }
 }


### PR DESCRIPTION
### Motivation
- Provide a way to bulk-sync crawled events from a JSON file upload to avoid sending large arrays in the request body. 
- Simplify security for administrative operations by allowing the `/admin/**` path for admin tooling and crawlers.

### Description
- Added a new multipart endpoint `POST /admin/events/sync` that accepts a `file` `MultipartFile`, streams a JSON array using Jackson's streaming parser, and batches upserts to `EventSyncService` with a `SYNC_BATCH_SIZE` of `500` to control memory usage. 
- Added `ObjectMapper` injection and robust error handling returning `400` if the uploaded file is not a JSON array. 
- Kept the existing `POST /admin/events/sync` that accepts a JSON array body and factored common logic into a private `runSync` helper. 
- Updated `SecurityConfig` to permit `"/admin/**"` (replacing the previous specific admin endpoints) so admin file-sync and other admin endpoints are accessible without authentication where intended.

### Testing
- Ran the project build with `./gradlew build` which completed successfully. 
- Executed the test suite with `./gradlew test` and all existing automated tests passed. 
- Manually exercised the new multipart sync by uploading a JSON array file locally to verify batching, upsert/skipped counters and the `400` response when the file is not a JSON array.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee2227a374832f87cc950502cca308)