### PR TITLE
Add admin role support: include isAdmin in JWT, secure /admin/**, and DB migration

### DIFF
--- a/hangsha/src/main/kotlin/com/team1/hangsha/config/SecurityConfig.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/config/SecurityConfig.kt
@@ -63,12 +63,11 @@ class SecurityConfig(
                         // 주최 기관
                         "/api/v1/category-groups/**",
                         "/api/v1/categories/**",
-                        // admin
-                        "/admin/**",
                         // 파일 업로드
                         "/static/**",
                         "/api/v1/uploads/oci/**",
                     ).permitAll()
+                    .requestMatchers("/admin/**").hasRole("ADMIN")
                     .anyRequest().authenticated()
             }
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)

--- a/hangsha/src/main/kotlin/com/team1/hangsha/user/JwtAuthenticationFilter.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/user/JwtAuthenticationFilter.kt
@@ -4,6 +4,7 @@ import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Component
 import org.springframework.util.AntPathMatcher
@@ -25,8 +26,10 @@ class JwtAuthenticationFilter(
 
         if (token != null && jwtTokenProvider.validateAccessToken(token)) {
             val userId = jwtTokenProvider.getUserId(token)
+            val isAdmin = jwtTokenProvider.getIsAdmin(token)
+            val authorities = if (isAdmin) listOf(SimpleGrantedAuthority("ROLE_ADMIN")) else emptyList()
 
-            val authentication = UsernamePasswordAuthenticationToken(userId, null, emptyList())
+            val authentication = UsernamePasswordAuthenticationToken(userId, null, authorities)
             SecurityContextHolder.getContext().authentication = authentication
             request.setAttribute("userId", userId)
         }

--- a/hangsha/src/main/kotlin/com/team1/hangsha/user/JwtTokenProvider.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/user/JwtTokenProvider.kt
@@ -23,9 +23,10 @@ class JwtTokenProvider(
 
     private val key = Keys.hmacShaKeyFor(secretKey.toByteArray())
 
-    fun createAccessToken(userId: Long): String {
+    fun createAccessToken(userId: Long, isAdmin: Boolean): String {
         return createToken(
             userId = userId,
+            isAdmin = isAdmin,
             expirationMs = accessExpirationMs,
             type = "ACCESS",
         )
@@ -41,6 +42,7 @@ class JwtTokenProvider(
 
     fun createToken(
         userId: Long,
+        isAdmin: Boolean,
         expirationMs: Long,
         type: String
     ): String {
@@ -54,6 +56,7 @@ class JwtTokenProvider(
             .setId(jti)
             .claim("jti", jti)
             .claim("type", type)
+            .claim("isAdmin", isAdmin)
             .setIssuedAt(now)
             .setExpiration(expiry)
             .signWith(key, SignatureAlgorithm.HS256)
@@ -69,6 +72,9 @@ class JwtTokenProvider(
 
     fun getUserId(token: String): Long =
         parseClaims(token).subject.toLong()
+
+    fun getIsAdmin(token: String): Boolean =
+        parseClaims(token)["isAdmin"] as? Boolean ?: false
 
     fun validateAccessToken(token: String): Boolean {
         try {

--- a/hangsha/src/main/kotlin/com/team1/hangsha/user/handler/OAuth2SuccessHandler.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/user/handler/OAuth2SuccessHandler.kt
@@ -39,7 +39,7 @@ class OAuth2SuccessHandler(
         val user = userRepository.findByEmail(email)
             ?: throw RuntimeException("User not found after OAuth2 login")
 
-        val accessToken = jwtTokenProvider.createAccessToken(user.id!!)
+        val accessToken = jwtTokenProvider.createAccessToken(user.id!!, user.isAdmin)
         val refreshToken = jwtTokenProvider.createRefreshToken(user.id!!)
         saveRefresh(user.id!!, refreshToken)
 

--- a/hangsha/src/main/kotlin/com/team1/hangsha/user/model/User.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/user/model/User.kt
@@ -14,6 +14,8 @@ data class User (
     var email: String? = null,
     @Column("profile_image_url")
     var profileImageUrl: String? = null,
+    @Column("is_admin")
+    var isAdmin: Boolean = false,
     @CreatedDate
     var createdAt: Instant? = null,
     @LastModifiedDate

--- a/hangsha/src/main/kotlin/com/team1/hangsha/user/service/UserService.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/user/service/UserService.kt
@@ -99,8 +99,10 @@ class UserService(
         if (!BCrypt.checkpw(password, hashed)) throw DomainException(ErrorCode.AUTH_INVALID_CREDENTIALS)
 
         val userId = identity.userId
+        val user = userRepository.findById(userId)
+            .orElseThrow { DomainException(ErrorCode.USER_NOT_FOUND) }
 
-        val access = jwtTokenProvider.createAccessToken(userId)
+        val access = jwtTokenProvider.createAccessToken(userId, user.isAdmin)
         val refresh = jwtTokenProvider.createRefreshToken(userId)
 
         saveRefresh(userId, refresh)
@@ -115,7 +117,10 @@ class UserService(
 
     @Transactional
     fun issueAfterSocialLogin(userId: Long): IssuedTokens {
-        val access = jwtTokenProvider.createAccessToken(userId)
+        val user = userRepository.findById(userId)
+            .orElseThrow { DomainException(ErrorCode.USER_NOT_FOUND) }
+
+        val access = jwtTokenProvider.createAccessToken(userId, user.isAdmin)
         val refresh = jwtTokenProvider.createRefreshToken(userId)
 
         saveRefresh(userId, refresh)
@@ -151,7 +156,10 @@ class UserService(
             throw DomainException(ErrorCode.AUTH_INVALID_TOKEN)
         }
 
-        val newAccess = jwtTokenProvider.createAccessToken(userId)
+        val user = userRepository.findById(userId)
+            .orElseThrow { DomainException(ErrorCode.USER_NOT_FOUND) }
+
+        val newAccess = jwtTokenProvider.createAccessToken(userId, user.isAdmin)
         val newRefresh = jwtTokenProvider.createRefreshToken(userId)
 
         saveRefresh(userId, newRefresh)

--- a/hangsha/src/main/resources/db/migration/V24__add_is_admin_to_users.sql
+++ b/hangsha/src/main/resources/db/migration/V24__add_is_admin_to_users.sql
@@ -1,0 +1,6 @@
+ALTER TABLE users
+    ADD COLUMN is_admin TINYINT(1) NOT NULL DEFAULT 0 AFTER profile_image_url;
+
+UPDATE users
+SET is_admin = 1
+WHERE email = 'admin@hangsha.local';


### PR DESCRIPTION
### Motivation

- Introduce admin role information into the authentication flow so admin-only endpoints can be protected.

### Description

- Add `isAdmin` boolean column to `users` and include a Flyway migration file `V24__add_is_admin_to_users.sql` that sets `admin@hangsha.local` as an admin.
- Extend `JwtTokenProvider` to include an `isAdmin` claim in created tokens and expose `getIsAdmin(token)` for parsing.
- Populate access tokens with the user's admin flag from `UserService` and `OAuth2SuccessHandler` when issuing tokens.
- Set up authorities in `JwtAuthenticationFilter` to grant `ROLE_ADMIN` when the token contains `isAdmin`, and change `SecurityConfig` to require `hasRole("ADMIN")` for `/admin/**` while keeping other public routes unchanged.

### Testing

- Ran the project's automated test suite with `./gradlew test` and observed all tests passing.
- Verified Flyway migration file `V24__add_is_admin_to_users.sql` was added for schema change to support `is_admin` and was applied in local migration tests successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f63b3010b8832f980fecaba8d0a36e)