### PR TITLE
feat: add admin role, event ordering, period events

### DIFF
--- a/hangsha/batch/src/main/kotlin/com/team1/hangsha/batch/job/ExtraSnuSyncRunner.kt
+++ b/hangsha/batch/src/main/kotlin/com/team1/hangsha/batch/job/ExtraSnuSyncRunner.kt
@@ -7,12 +7,14 @@ import com.team1.hangsha.batch.crawler.ProgramEvent
 import com.team1.hangsha.common.upload.OciUploadService
 import com.team1.hangsha.event.dto.core.CrawledDetailSession
 import com.team1.hangsha.event.dto.core.CrawledProgramEvent
+import com.team1.hangsha.event.model.EventPeriodPolicy
 import com.team1.hangsha.event.service.EventSyncService
 import org.springframework.boot.ApplicationArguments
 import org.springframework.boot.ApplicationRunner
 import org.springframework.stereotype.Component
 import java.nio.file.Files
 import java.nio.file.Path
+import java.time.LocalDate
 import kotlin.system.exitProcess
 
 @Component
@@ -50,7 +52,9 @@ class ExtraSnuSyncRunner(
                 val events = if (!opt.withDetails) {
                     baseEvents
                 } else {
-                    crawler.enrichDetails(baseEvents, ociUploadService) // { e -> e.status != "모집마감" } // @TODO: 위의 0001, 0002, ... 와 같이 매직 넘버라, ENUM화?
+                    crawler.enrichDetails(baseEvents, ociUploadService) { e ->
+                        !e.isPeriodEventFromList()
+                    }
                 }
 
                 // dumpOnly 여부와 상관없이 이미지 업로드는 항상 수행한다.
@@ -130,6 +134,18 @@ private data class BatchArgs(
             )
         }
     }
+}
+
+private fun ProgramEvent.isPeriodEventFromList(): Boolean {
+    val title = title?.trim().orEmpty()
+    val eventStart = activityStart?.let { LocalDate.parse(it).atStartOfDay() }
+    val eventEnd = activityEnd?.let { LocalDate.parse(it).atTime(23, 59, 59) }
+
+    return EventPeriodPolicy.isPeriodEvent(
+        title = title,
+        eventStart = eventStart,
+        eventEnd = eventEnd,
+    )
 }
 
 private fun ProgramEvent.toCrawledProgramEvent(): CrawledProgramEvent =

--- a/hangsha/src/main/kotlin/com/team1/hangsha/config/SecurityConfig.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/config/SecurityConfig.kt
@@ -63,12 +63,11 @@ class SecurityConfig(
                         // 주최 기관
                         "/api/v1/category-groups/**",
                         "/api/v1/categories/**",
-                        // admin
-                        "/admin/**",
                         // 파일 업로드
                         "/static/**",
                         "/api/v1/uploads/oci/**",
                     ).permitAll()
+                    .requestMatchers("/admin/**").hasRole("ADMIN")
                     .anyRequest().authenticated()
             }
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)

--- a/hangsha/src/main/kotlin/com/team1/hangsha/event/repository/EventQueryRepository.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/event/repository/EventQueryRepository.kt
@@ -40,7 +40,7 @@ class EventQueryRepository(
 
             appendExcludedKeywordsFilter(userId)
 
-            append("\nORDER BY COALESCE(e.event_start, e.apply_start) ASC, e.id ASC")
+            appendEventOrderBy(userId)
         }
 
         val params = mutableMapOf<String, Any>(
@@ -130,7 +130,7 @@ class EventQueryRepository(
 
             appendExcludedKeywordsFilter(userId)
 
-            append("\nORDER BY COALESCE(e.event_start, e.apply_start) DESC, e.id DESC")
+            appendEventOrderBy(userId)
             append("\nLIMIT :limit OFFSET :offset")
         }
 
@@ -250,6 +250,33 @@ private fun StringBuilder.appendExcludedKeywordsFilter(userId: Long?) {
                 OR COALESCE(e.main_content_html, '') LIKE CONCAT('%', uek.keyword, '%')
               )
           )
+        """.trimIndent()
+    )
+}
+
+private fun StringBuilder.appendEventOrderBy(userId: Long?) {
+    if (userId == null) {
+        append("\nORDER BY COALESCE(e.event_start, e.apply_start) ASC, e.id ASC")
+        return
+    }
+
+    val matchedPriorityExpr = """
+        (
+          SELECT MIN(uic.priority)
+          FROM user_interest_categories uic
+          WHERE uic.user_id = :userId
+            AND uic.category_id IN (e.status_id, e.event_type_id, e.org_id)
+        )
+    """.trimIndent()
+
+    append(
+        """
+
+        ORDER BY
+          CASE WHEN $matchedPriorityExpr IS NULL THEN 1 ELSE 0 END ASC,
+          $matchedPriorityExpr ASC,
+          COALESCE(e.event_start, e.apply_start) ASC,
+          e.id ASC
         """.trimIndent()
     )
 }

--- a/hangsha/src/main/kotlin/com/team1/hangsha/event/service/EventService.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/event/service/EventService.kt
@@ -60,11 +60,8 @@ class EventService(
             }
         }
 
-        fun effectiveStart(e: Event): LocalDateTime =
-            listOfNotNull(e.applyStart, e.eventStart).minOrNull() ?: fromStart
-
-        fun effectiveEnd(e: Event): LocalDateTime =
-            listOfNotNull(e.applyEnd, e.eventEnd).maxOrNull() ?: effectiveStart(e)
+        fun sortStart(e: Event): LocalDateTime =
+            e.eventStart ?: e.applyStart ?: fromStart
 
         fun addRangeToBuckets(event: Event, start: LocalDateTime?, end: LocalDateTime?) {
             val rangeStart = start ?: return
@@ -101,7 +98,7 @@ class EventService(
             .mapValues { (_, dayEvents) ->
                 val sorted = dayEvents.sortedWith(
                     compareBy<Event> { it.matchedInterestPriority(interestPriorityByCategoryId) ?: Int.MAX_VALUE }
-                        .thenBy { effectiveStart(it) }
+                        .thenBy { sortStart(it) }
                         .thenBy { it.id ?: Long.MAX_VALUE }
                 )
                 MonthEventResponse.DayBucket(

--- a/hangsha/src/main/kotlin/com/team1/hangsha/event/service/EventService.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/event/service/EventService.kt
@@ -100,7 +100,9 @@ class EventService(
             .toSortedMap()
             .mapValues { (_, dayEvents) ->
                 val sorted = dayEvents.sortedWith(
-                    compareBy<Event> { effectiveStart(it) }.thenBy { it.id ?: Long.MAX_VALUE }
+                    compareBy<Event> { it.matchedInterestPriority(interestPriorityByCategoryId) ?: Int.MAX_VALUE }
+                        .thenBy { effectiveStart(it) }
+                        .thenBy { it.id ?: Long.MAX_VALUE }
                 )
                 MonthEventResponse.DayBucket(
                     events = sorted.map { e ->

--- a/hangsha/src/main/kotlin/com/team1/hangsha/user/JwtAuthenticationFilter.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/user/JwtAuthenticationFilter.kt
@@ -4,6 +4,7 @@ import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Component
 import org.springframework.util.AntPathMatcher
@@ -25,8 +26,10 @@ class JwtAuthenticationFilter(
 
         if (token != null && jwtTokenProvider.validateAccessToken(token)) {
             val userId = jwtTokenProvider.getUserId(token)
+            val isAdmin = jwtTokenProvider.getIsAdmin(token)
+            val authorities = if (isAdmin) listOf(SimpleGrantedAuthority("ROLE_ADMIN")) else emptyList()
 
-            val authentication = UsernamePasswordAuthenticationToken(userId, null, emptyList())
+            val authentication = UsernamePasswordAuthenticationToken(userId, null, authorities)
             SecurityContextHolder.getContext().authentication = authentication
             request.setAttribute("userId", userId)
         }

--- a/hangsha/src/main/kotlin/com/team1/hangsha/user/JwtTokenProvider.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/user/JwtTokenProvider.kt
@@ -23,7 +23,7 @@ class JwtTokenProvider(
 
     private val key = Keys.hmacShaKeyFor(secretKey.toByteArray())
 
-    fun createAccessToken(userId: Long, isAdmin: Boolean): String {
+    fun createAccessToken(userId: Long, isAdmin: Boolean = false): String {
         return createToken(
             userId = userId,
             isAdmin = isAdmin,
@@ -37,6 +37,7 @@ class JwtTokenProvider(
             userId = userId,
             expirationMs = refreshExpirationMs,
             type = "REFRESH",
+            isAdmin = false,
         )
     }
 

--- a/hangsha/src/main/kotlin/com/team1/hangsha/user/JwtTokenProvider.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/user/JwtTokenProvider.kt
@@ -23,9 +23,10 @@ class JwtTokenProvider(
 
     private val key = Keys.hmacShaKeyFor(secretKey.toByteArray())
 
-    fun createAccessToken(userId: Long): String {
+    fun createAccessToken(userId: Long, isAdmin: Boolean): String {
         return createToken(
             userId = userId,
+            isAdmin = isAdmin,
             expirationMs = accessExpirationMs,
             type = "ACCESS",
         )
@@ -41,6 +42,7 @@ class JwtTokenProvider(
 
     fun createToken(
         userId: Long,
+        isAdmin: Boolean,
         expirationMs: Long,
         type: String
     ): String {
@@ -54,6 +56,7 @@ class JwtTokenProvider(
             .setId(jti)
             .claim("jti", jti)
             .claim("type", type)
+            .claim("isAdmin", isAdmin)
             .setIssuedAt(now)
             .setExpiration(expiry)
             .signWith(key, SignatureAlgorithm.HS256)
@@ -69,6 +72,9 @@ class JwtTokenProvider(
 
     fun getUserId(token: String): Long =
         parseClaims(token).subject.toLong()
+
+    fun getIsAdmin(token: String): Boolean =
+        parseClaims(token)["isAdmin"] as? Boolean ?: false
 
     fun validateAccessToken(token: String): Boolean {
         try {

--- a/hangsha/src/main/kotlin/com/team1/hangsha/user/handler/OAuth2SuccessHandler.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/user/handler/OAuth2SuccessHandler.kt
@@ -39,7 +39,7 @@ class OAuth2SuccessHandler(
         val user = userRepository.findByEmail(email)
             ?: throw RuntimeException("User not found after OAuth2 login")
 
-        val accessToken = jwtTokenProvider.createAccessToken(user.id!!)
+        val accessToken = jwtTokenProvider.createAccessToken(user.id!!, user.isAdmin)
         val refreshToken = jwtTokenProvider.createRefreshToken(user.id!!)
         saveRefresh(user.id!!, refreshToken)
 

--- a/hangsha/src/main/kotlin/com/team1/hangsha/user/model/User.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/user/model/User.kt
@@ -14,6 +14,8 @@ data class User (
     var email: String? = null,
     @Column("profile_image_url")
     var profileImageUrl: String? = null,
+    @Column("is_admin")
+    var isAdmin: Boolean = false,
     @CreatedDate
     var createdAt: Instant? = null,
     @LastModifiedDate

--- a/hangsha/src/main/kotlin/com/team1/hangsha/user/service/UserService.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/user/service/UserService.kt
@@ -99,8 +99,10 @@ class UserService(
         if (!BCrypt.checkpw(password, hashed)) throw DomainException(ErrorCode.AUTH_INVALID_CREDENTIALS)
 
         val userId = identity.userId
+        val user = userRepository.findById(userId)
+            .orElseThrow { DomainException(ErrorCode.USER_NOT_FOUND) }
 
-        val access = jwtTokenProvider.createAccessToken(userId)
+        val access = jwtTokenProvider.createAccessToken(userId, user.isAdmin)
         val refresh = jwtTokenProvider.createRefreshToken(userId)
 
         saveRefresh(userId, refresh)
@@ -115,7 +117,10 @@ class UserService(
 
     @Transactional
     fun issueAfterSocialLogin(userId: Long): IssuedTokens {
-        val access = jwtTokenProvider.createAccessToken(userId)
+        val user = userRepository.findById(userId)
+            .orElseThrow { DomainException(ErrorCode.USER_NOT_FOUND) }
+
+        val access = jwtTokenProvider.createAccessToken(userId, user.isAdmin)
         val refresh = jwtTokenProvider.createRefreshToken(userId)
 
         saveRefresh(userId, refresh)
@@ -151,7 +156,10 @@ class UserService(
             throw DomainException(ErrorCode.AUTH_INVALID_TOKEN)
         }
 
-        val newAccess = jwtTokenProvider.createAccessToken(userId)
+        val user = userRepository.findById(userId)
+            .orElseThrow { DomainException(ErrorCode.USER_NOT_FOUND) }
+
+        val newAccess = jwtTokenProvider.createAccessToken(userId, user.isAdmin)
         val newRefresh = jwtTokenProvider.createRefreshToken(userId)
 
         saveRefresh(userId, newRefresh)

--- a/hangsha/src/main/resources/db/migration/V24__add_is_admin_to_users.sql
+++ b/hangsha/src/main/resources/db/migration/V24__add_is_admin_to_users.sql
@@ -1,0 +1,6 @@
+ALTER TABLE users
+    ADD COLUMN is_admin TINYINT(1) NOT NULL DEFAULT 0 AFTER profile_image_url;
+
+UPDATE users
+SET is_admin = 1
+WHERE email = 'admin@hangsha.local';

--- a/hangsha/src/test/kotlin/com/team1/hangsha/EventIntegrationTest.kt
+++ b/hangsha/src/test/kotlin/com/team1/hangsha/EventIntegrationTest.kt
@@ -198,7 +198,7 @@ class EventIntegrationTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `이벤트 일 조회 기본 page size total items 동작하고 정렬 desc 이다`() {
+    fun `이벤트 일 조회 기본 page size total items 동작하고 정렬 asc 이다`() {
         val date = LocalDate.now()
         val dayStart = date.atStartOfDay()
 
@@ -224,7 +224,7 @@ class EventIntegrationTest : IntegrationTestBase() {
 
         val root = objectMapper.readTree(res.response.contentAsString)
         val titles = root["items"].map { it["title"].asText() }
-        assertEquals(listOf("D3", "D2", "D1"), titles)
+        assertEquals(listOf("D1", "D2", "D3"), titles)
     }
 
     @Test


### PR DESCRIPTION
- 기간제 행사 판정 로직 변경
목록 데이터 기준으로 기간제 행사면, 해당 행사를 하나로 판정 (상세 페이지 안 들어감) 
목록 데이터 기준으로 기간제 행사가 아니면, 상세 페이지에 들어가서 회차 확인하고 각자를 따로 저장

- events/day, events/month 모두 같은 정렬 기준 사용
비로그인: 행사 시작 시각 ASC → event id ASC
로그인: 사용자 관심 카테고리 우선순위 ASC → 행사 시작 시각 ASC → event id ASC
- 차이
events/day: DB에서 정렬 후 pagination
events/month: 월 범위 조회 후, 날짜별 bucket 내부에서 동일 기준으로 정렬

- 어드민 계정 만들고 admin role 부여 / 어드민 페이지 → 어드민 계정으로 로그인되었을 시만 접근 가능, 어드민 API 사용 가능 
(실제 어드민 페이지는 프론트에서 만들어야 할듯?)