### PR TITLE
fix: align month bucket with isPeriodEvent rule

### DIFF
--- a/hangsha/src/main/kotlin/com/team1/hangsha/event/service/EventService.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/event/service/EventService.kt
@@ -81,8 +81,11 @@ class EventService(
         }
 
         for (e in events) {
-            addRangeToBuckets(e, e.eventStart, e.eventEnd)
-            addRangeToBuckets(e, e.applyStart, e.applyEnd)
+            if (e.isPeriodEvent) {
+                addRangeToBuckets(e, e.applyStart, e.applyEnd)
+            } else {
+                addRangeToBuckets(e, e.eventStart, e.eventEnd)
+            }
         }
 
         val auth = userId != null


### PR DESCRIPTION
/month api에서 from과 to 값에 따라 특정 날에 포함되는 이벤트가 달라지는 문제 수정:

DB에서 일별로 가져오는 SQL에는 isPeriodEvent를 넣었는데, 정작 프론트로 보내주기 위해 일별 버킷에 넣는 거에서 isPeriodEvent에 따른 분기를 빼먹었네요 
--> /day의 동작이 정답입니다

구체적으로는:

1. DB에서 from~to 범위에 걸치는 이벤트를 조회한다.
 - isPeriodEvent=true → apply 기간 기준
 - isPeriodEvent=false → event 기간 기준

2. 조회된 이벤트를 날짜별 bucket에 넣는다.

정상 동작:
 - isPeriodEvent=true → applyStart - applyEnd 날짜들에만 넣음
 - isPeriodEvent=false → eventStart - eventEnd 날짜들에만 넣음

(이 문제가 발생한 원인인) 비정상 동작:

 - isPeriodEvent에 상관 없이, applyStart - applyEnd / eventStart - eventEnd에 해당하는 모든 날짜들에 넣음