### PR TITLE
소셜 로그인 새로고침 시 로그인 풀림 - SameSite 설정 변경

### DIFF
--- a/hangsha/src/main/kotlin/com/team1/hangsha/auth/service/AuthService.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/auth/service/AuthService.kt
@@ -103,7 +103,6 @@ class AuthService(
     }
 
     private fun getKakaoProfile(code: String): SocialUserProfile {
-        println(">>> DEBUG: ID=$kakaoClientId, SECRET=$kakaoClientSecret")
         val tokenUrl = "https://kauth.kakao.com/oauth/token"
 
         val headers = HttpHeaders().apply { contentType = MediaType.APPLICATION_FORM_URLENCODED }

--- a/hangsha/src/main/resources/application.yml
+++ b/hangsha/src/main/resources/application.yml
@@ -121,8 +121,8 @@ app:
 auth:
   refresh-cookie:
     secure: true
-    same-site: Lax
-    domain: ".wafflestudio.com"
+    # OAuth 콜백 302(cross-site 리다이렉트)에서 심기는 쿠키는 SameSite=Lax면 브라우저가 저장을 거부 : None + Secure로 설정 변경
+    same-site: None
 ---
 # ==========================================
 # prod
@@ -137,5 +137,5 @@ app:
 auth:
   refresh-cookie:
     secure: true
-    same-site: Lax
-    domain: ".wafflestudio.com"
+    # OAuth 콜백 302(cross-site 리다이렉트)에서 심기는 쿠키는 SameSite=Lax면 브라우저가 저장을 거부 : None + Secure로 설정 변경
+    same-site: None


### PR DESCRIPTION

## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝 작업 내용

소셜 로그인(카카오/구글/네이버) 후 새로고침 시 `POST /api/v1/auth/refresh`가 **401**을 반환하지만 이메일 로그인은 정상 동작
➡️
OAuth 콜백 핸들러 응답에서는 refresh cookie가 `Set-Cookie`로 정상적으로 심어진 것 확인 (소셜 로그인에서만 refresh cookie 안 심는 것 X)
➡️
- refresh 쿠키는 `kauth.kakao.com` 등 외부 origin에서 cross-site로 리다이렉트되어 들어온 콜백(302) 응답에서 심기는데, 쿠키 속성이 `SameSite=Lax`
- 브라우저가 cross-site 맥락에서 들어온 `SameSite=Lax` 쿠키의 저장을 거부한다고 추정 (DevTools `Application → Cookies`에 저장되지 않음 확인)

➡️
이 원인 때문인지 확인하기 위해 `application.yml`의 `refresh-cookie.same-site`설정을 Lax에서 None으로 변경함
(추가적으로 사용되지 않던 `refresh-cookie.domain`설정 제거)


## ✅ 체크리스트
- [ ] 로컬에서 정상 동작 확인
- [ ] 기존 기능에 영향 없음
- [ ] 테스트 통과 (또는 테스트 없음)
- [ ] 브레이킹 체인지 여부 확인

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
