### PR TITLE
feat: 행사 목록 GET 시 제외 키워드 제외 옵션, 행사 개수 조회 API 추가 

### DIFF
--- a/hangsha/src/main/kotlin/com/team1/hangsha/event/controller/EventController.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/event/controller/EventController.kt
@@ -4,6 +4,7 @@ import com.team1.hangsha.event.dto.response.Calendar.MonthEventResponse
 import com.team1.hangsha.event.dto.response.Calendar.DayEventResponse
 import com.team1.hangsha.event.dto.response.TitleSearchEventResponse
 import com.team1.hangsha.event.dto.response.DetailEventResponse
+import com.team1.hangsha.event.dto.response.EventCountResponse
 import com.team1.hangsha.event.service.EventService
 import com.team1.hangsha.user.LoggedInUser
 import com.team1.hangsha.user.model.User
@@ -31,6 +32,7 @@ class EventController(
         @RequestParam("statusId", required = false) statusIds: List<Long>?,
         @RequestParam("eventTypeId", required = false) eventTypeIds: List<Long>?,
         @RequestParam("orgId", required = false) orgIds: List<Long>?,
+        @RequestParam("applyExcludedKeywords", defaultValue = "true") applyExcludedKeywords: Boolean,
     ): MonthEventResponse =
         eventService.getMonthEvents(
             from = from,
@@ -39,6 +41,27 @@ class EventController(
             eventTypeIds = eventTypeIds,
             orgIds = orgIds,
             userId = user?.id,
+            applyExcludedKeywords = applyExcludedKeywords,
+        )
+
+    @GetMapping("/count")
+    fun count(
+        @Parameter(hidden = true) @LoggedInUser user: User?,
+        @RequestParam("from") @DateTimeFormat(iso = ISO.DATE) from: LocalDate,
+        @RequestParam("to") @DateTimeFormat(iso = ISO.DATE) to: LocalDate,
+        @RequestParam("statusId", required = false) statusIds: List<Long>?,
+        @RequestParam("eventTypeId", required = false) eventTypeIds: List<Long>?,
+        @RequestParam("orgId", required = false) orgIds: List<Long>?,
+        @RequestParam("applyExcludedKeywords", defaultValue = "true") applyExcludedKeywords: Boolean,
+    ): EventCountResponse =
+        eventService.countEvents(
+            from = from,
+            to = to,
+            statusIds = statusIds,
+            eventTypeIds = eventTypeIds,
+            orgIds = orgIds,
+            userId = user?.id,
+            applyExcludedKeywords = applyExcludedKeywords,
         )
 
     @GetMapping("/{eventId}")
@@ -57,6 +80,7 @@ class EventController(
         @RequestParam("statusId", required = false) statusIds: List<Long>?,
         @RequestParam("eventTypeId", required = false) eventTypeIds: List<Long>?,
         @RequestParam("orgId", required = false) orgIds: List<Long>?,
+        @RequestParam("applyExcludedKeywords", defaultValue = "true") applyExcludedKeywords: Boolean,
     ): DayEventResponse =
         eventService.getDayEvents(
             date = date,
@@ -66,6 +90,7 @@ class EventController(
             eventTypeIds = eventTypeIds,
             orgIds = orgIds,
             userId = user?.id,
+            applyExcludedKeywords = applyExcludedKeywords,
         )
 
     @GetMapping("/search/title")

--- a/hangsha/src/main/kotlin/com/team1/hangsha/event/dto/response/EventCountResponse.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/event/dto/response/EventCountResponse.kt
@@ -1,0 +1,5 @@
+package com.team1.hangsha.event.dto.response
+
+data class EventCountResponse(
+    val count: Int,
+)

--- a/hangsha/src/main/kotlin/com/team1/hangsha/event/repository/EventQueryRepository.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/event/repository/EventQueryRepository.kt
@@ -20,6 +20,7 @@ class EventQueryRepository(
         eventTypeIds: List<Long>?,
         orgIds: List<Long>?,
         userId: Long?,
+        applyExcludedKeywords: Boolean = true,
     ): List<Event> {
         val sql = buildString {
             append(
@@ -49,7 +50,9 @@ class EventQueryRepository(
             if (!eventTypeIds.isNullOrEmpty()) append("\n  AND event_type_id IN (:eventTypeIds)")
             if (!orgIds.isNullOrEmpty()) append("\n  AND org_id IN (:orgIds)")
 
-            appendExcludedKeywordsFilter(userId)
+            if (applyExcludedKeywords) {
+                appendExcludedKeywordsFilter(userId)
+            }
 
             appendEventOrderBy(userId)
         }
@@ -66,12 +69,66 @@ class EventQueryRepository(
         return jdbc.query(sql, params) { rs, _ -> rs.toEvent() }
     }
 
+    fun countInRange(
+        fromStart: LocalDateTime,
+        toEndExclusive: LocalDateTime,
+        statusIds: List<Long>?,
+        eventTypeIds: List<Long>?,
+        orgIds: List<Long>?,
+        userId: Long?,
+        applyExcludedKeywords: Boolean = true,
+    ): Int {
+        val sql = buildString {
+            append(
+                """
+            SELECT COUNT(*)
+            FROM events e
+            WHERE e.admin_deleted = false
+              AND (
+                (
+                  e.is_period_event = true
+                  AND e.apply_start IS NOT NULL
+                  AND e.apply_start < :toEndExclusive
+                  AND COALESCE(e.apply_end, e.apply_start) >= :fromStart
+                )
+                OR
+                (
+                  e.is_period_event = false
+                  AND e.event_start IS NOT NULL
+                  AND e.event_start < :toEndExclusive
+                  AND COALESCE(e.event_end, e.event_start) >= :fromStart
+                )
+              )
+            """.trimIndent()
+            )
+
+            if (!statusIds.isNullOrEmpty()) append("\n  AND status_id IN (:statusIds)")
+            if (!eventTypeIds.isNullOrEmpty()) append("\n  AND event_type_id IN (:eventTypeIds)")
+            if (!orgIds.isNullOrEmpty()) append("\n  AND org_id IN (:orgIds)")
+            if (applyExcludedKeywords) {
+                appendExcludedKeywordsFilter(userId)
+            }
+        }
+
+        val params = mutableMapOf<String, Any>(
+            "fromStart" to Timestamp.valueOf(fromStart),
+            "toEndExclusive" to Timestamp.valueOf(toEndExclusive),
+        )
+        if (!statusIds.isNullOrEmpty()) params["statusIds"] = statusIds
+        if (!eventTypeIds.isNullOrEmpty()) params["eventTypeIds"] = eventTypeIds
+        if (!orgIds.isNullOrEmpty()) params["orgIds"] = orgIds
+        if (userId != null) params["userId"] = userId
+
+        return jdbc.queryForObject(sql, params, Int::class.java) ?: 0
+    }
+
     fun countOnDay(
         date: LocalDate,
         statusIds: List<Long>?,
         eventTypeIds: List<Long>?,
         orgIds: List<Long>?,
         userId: Long?,
+        applyExcludedKeywords: Boolean = true,
     ): Int {
         val dayStart = date.atStartOfDay()
         val dayEndExclusive = date.plusDays(1).atStartOfDay()
@@ -103,7 +160,9 @@ class EventQueryRepository(
             if (!eventTypeIds.isNullOrEmpty()) append("\n  AND event_type_id IN (:eventTypeIds)")
             if (!orgIds.isNullOrEmpty()) append("\n  AND org_id IN (:orgIds)")
 
-            appendExcludedKeywordsFilter(userId)
+            if (applyExcludedKeywords) {
+                appendExcludedKeywordsFilter(userId)
+            }
         }
 
         val params = mutableMapOf<String, Any>(
@@ -126,6 +185,7 @@ class EventQueryRepository(
         page: Int,
         size: Int,
         userId: Long?,
+        applyExcludedKeywords: Boolean = true,
     ): List<Event> {
         val safePage = max(1, page)
         val safeSize = max(1, size)
@@ -161,7 +221,9 @@ class EventQueryRepository(
             if (!eventTypeIds.isNullOrEmpty()) append("\n  AND event_type_id IN (:eventTypeIds)")
             if (!orgIds.isNullOrEmpty()) append("\n  AND org_id IN (:orgIds)")
 
-            appendExcludedKeywordsFilter(userId)
+            if (applyExcludedKeywords) {
+                appendExcludedKeywordsFilter(userId)
+            }
 
             appendEventOrderBy(userId)
             append("\nLIMIT :limit OFFSET :offset")

--- a/hangsha/src/main/kotlin/com/team1/hangsha/event/service/EventService.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/event/service/EventService.kt
@@ -6,6 +6,7 @@ import com.team1.hangsha.common.error.ErrorCode
 import com.team1.hangsha.event.dto.core.EventDto
 import com.team1.hangsha.event.dto.response.Calendar.MonthEventResponse
 import com.team1.hangsha.event.dto.response.DetailEventResponse
+import com.team1.hangsha.event.dto.response.EventCountResponse
 import com.team1.hangsha.event.dto.response.Calendar.DayEventResponse
 import com.team1.hangsha.event.dto.response.TitleSearchEventResponse
 import com.team1.hangsha.event.model.Event
@@ -32,6 +33,7 @@ class EventService(
         eventTypeIds: List<Long>?,
         orgIds: List<Long>?,
         userId: Long?,
+        applyExcludedKeywords: Boolean = true,
     ): MonthEventResponse {
         if (from.isAfter(to)) {
             throw DomainException(ErrorCode.INVALID_REQUEST, "from은 to보다 이후일 수 없습니다")
@@ -47,6 +49,7 @@ class EventService(
             eventTypeIds = eventTypeIds,
             orgIds = orgIds,
             userId = userId,
+            applyExcludedKeywords = applyExcludedKeywords,
         )
 
         val interestPriorityByCategoryId = loadInterestMap(userId)
@@ -120,6 +123,32 @@ class EventService(
         )
     }
 
+
+    fun countEvents(
+        from: LocalDate,
+        to: LocalDate,
+        statusIds: List<Long>?,
+        eventTypeIds: List<Long>?,
+        orgIds: List<Long>?,
+        userId: Long?,
+        applyExcludedKeywords: Boolean = true,
+    ): EventCountResponse {
+        if (from.isAfter(to)) {
+            throw DomainException(ErrorCode.INVALID_REQUEST, "from은 to보다 이후일 수 없습니다")
+        }
+
+        val count = eventQueryRepository.countInRange(
+            fromStart = from.atStartOfDay(),
+            toEndExclusive = to.plusDays(1).atStartOfDay(),
+            statusIds = statusIds,
+            eventTypeIds = eventTypeIds,
+            orgIds = orgIds,
+            userId = userId,
+            applyExcludedKeywords = applyExcludedKeywords,
+        )
+        return EventCountResponse(count = count)
+    }
+
     fun getEventDetail(eventId: Long, userId: Long?): DetailEventResponse {
         val event = eventRepository.findVisibleById(eventId)
             ?: throw DomainException(ErrorCode.EVENT_NOT_FOUND)
@@ -139,9 +168,14 @@ class EventService(
         eventTypeIds: List<Long>?,
         orgIds: List<Long>?,
         userId: Long?,
+        applyExcludedKeywords: Boolean = true,
     ): DayEventResponse {
-        val total = eventQueryRepository.countOnDay(date, statusIds, eventTypeIds, orgIds, userId)
-        val events = eventQueryRepository.findOnDayPaged(date, statusIds, eventTypeIds, orgIds, page, size, userId)
+        val total = eventQueryRepository.countOnDay(
+            date, statusIds, eventTypeIds, orgIds, userId, applyExcludedKeywords
+        )
+        val events = eventQueryRepository.findOnDayPaged(
+            date, statusIds, eventTypeIds, orgIds, page, size, userId, applyExcludedKeywords
+        )
 
         val interestPriorityByCategoryId = loadInterestMap(userId)
         val auth = userId != null


### PR DESCRIPTION
1. GET:
GET /api/v1/events/month?from=2026-06-01&to=2026-06-30&applyExcludedKeywords=false 
GET /api/v1/events/day?date=2026-06-14&applyExcludedKeywords=false

과 같이, &로 붙여주면 됨
(기존에 쓰이던 부분은 상관 없음, default가 true임)

2. 행사 개수 조회
GET /api/v1/events/count?from=2026-06-01&to=2026-06-30

필터링도 가능.

GET /api/v1/events/count?from=2026-06-01&to=2026-06-30&statusId=1&eventTypeId=2&orgId=3

응답은

{
  "count": 37
}