### PR TITLE
fix: prevent Manticore table from being dropped on every server startup

### DIFF
--- a/hangsha/common/src/main/kotlin/com/team1/hangsha/search/ManticoreTableInitializer.kt
+++ b/hangsha/common/src/main/kotlin/com/team1/hangsha/search/ManticoreTableInitializer.kt
@@ -19,16 +19,15 @@ class ManticoreTableInitializer(
     @PostConstruct
     fun init() {
         try {
-            sqlRaw("DROP TABLE IF EXISTS events_search")
             sqlRaw("""
-                CREATE TABLE events_search(
+                CREATE TABLE IF NOT EXISTS events_search(
                     title_tokens   TEXT,
                     content_tokens TEXT,
                     title_raw      TEXT,
                     content_raw    TEXT
                 ) min_infix_len='2' charset_table='non_cjk, U+AC00..U+D7AF, U+1100..U+11FF, U+3130..U+318F'
             """.trimIndent())
-            log.info("Manticore events_search table (re)created with 4-field schema")
+            log.info("Manticore events_search table ensured")
         } catch (e: Exception) {
             log.warn("Manticore table init failed: ${e.message}")
         }


### PR DESCRIPTION


## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝 작업 내용

api서버 올라갈때, table이 없는 경우에만 create하도록 변경

## ✅ 체크리스트
- [ ] 로컬에서 정상 동작 확인
- [ ] 기존 기능에 영향 없음
- [ ] 테스트 통과 (또는 테스트 없음)
- [ ] 브레이킹 체인지 여부 확인

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
