### PR TITLE
feat: SNU 캘린더 크롤링 파이프라인 추가 

### DIFF
--- a/hangsha/batch/src/main/kotlin/com/team1/hangsha/batch/BatchApplication.kt
+++ b/hangsha/batch/src/main/kotlin/com/team1/hangsha/batch/BatchApplication.kt
@@ -1,29 +1,37 @@
 package com.team1.hangsha.batch
 
-import com.team1.hangsha.config.DatabaseConfig
-import com.team1.hangsha.config.TestValueLogger
 import com.team1.hangsha.com.team1.hangsha.config.JacksonConfig
-import com.team1.hangsha.common.upload.OciUploadService
-import com.team1.hangsha.config.OciConfig
-import com.team1.hangsha.event.service.EventSyncService
 import org.springframework.boot.WebApplicationType
+import org.springframework.boot.autoconfigure.data.jdbc.JdbcRepositoriesAutoConfiguration
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
+import org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration
+import org.springframework.boot.autoconfigure.jdbc.JdbcTemplateAutoConfiguration
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.builder.SpringApplicationBuilder
 import org.springframework.context.annotation.Import
 
 @SpringBootApplication
 @Import(
-    DatabaseConfig::class,
     JacksonConfig::class,
-    EventSyncService::class,
-    TestValueLogger::class,
-    OciConfig::class,
-    OciUploadService::class,
 ) // for explicit bean import
 class BatchApplication
 
 fun main(args: Array<String>) {
-    SpringApplicationBuilder(BatchApplication::class.java)
+    val builder = SpringApplicationBuilder(BatchApplication::class.java)
         .web(WebApplicationType.NONE)
-        .run(*args)
+
+    if (args.any { it == "--job=snu-calendar-dump" }) {
+        builder.properties(
+            mapOf(
+                "spring.autoconfigure.exclude" to listOf(
+                    DataSourceAutoConfiguration::class.java.name,
+                    DataSourceTransactionManagerAutoConfiguration::class.java.name,
+                    JdbcTemplateAutoConfiguration::class.java.name,
+                    JdbcRepositoriesAutoConfiguration::class.java.name,
+                ).joinToString(",")
+            )
+        )
+    }
+
+    builder.run(*args)
 }

--- a/hangsha/batch/src/main/kotlin/com/team1/hangsha/batch/crawler/SnuCalendarCrawler.kt
+++ b/hangsha/batch/src/main/kotlin/com/team1/hangsha/batch/crawler/SnuCalendarCrawler.kt
@@ -69,7 +69,9 @@ class SnuCalendarCrawler(
                 } else {
                     parseDetailHtml(detailHtml, item, detailUrl)
                 }
-                result += event
+                if (event != null) {
+                    result += event
+                }
 
                 if (delayMsBetweenDetails > 0) Thread.sleep(delayMsBetweenDetails)
             }
@@ -106,30 +108,40 @@ class SnuCalendarCrawler(
         return ParsedListPage(hasNoResultsMessage = false, items = items)
     }
 
-    fun parseDetailHtml(html: String, listItem: ListItem, sourceUrl: String): CrawledProgramEvent {
+    fun parseDetailHtml(html: String, listItem: ListItem, sourceUrl: String): CrawledProgramEvent? {
         val doc = Jsoup.parse(html, sourceUrl)
         val content = doc.selectFirst(".board-view .content") ?: doc.selectFirst(".view .content")
         val contentHtml = content?.html()?.trim()?.takeIf { it.isNotBlank() }
         val contentText = content?.text()?.normalize().orEmpty()
+        if (contentText.contains("비교과")) {
+            if (debug) println("[SNU-CALENDAR] skip duplicate extra-snu candidate url=$sourceUrl")
+            return null
+        }
+        val contentLines = extractContentLines(content)
 
         val title = doc.selectFirst(".board-view .header .title")?.text()?.normalize()
             ?: doc.selectFirst("meta[property=og:title]")?.attr("content")?.substringBefore(" - ")?.normalize()
             ?: listItem.title
-        val listPeriod = parseDotRangeToYmd(
+        val listPeriod = parseListDateRange(
             doc.selectFirst(".board-view .header .date")?.text()?.normalize() ?: listItem.dateText
         )
-        val detailDateTime = parseBestEventDateTime(contentText)
-        val applyEnd = parseApplyEnd(contentText)
-        val location = parseLocation(contentText)
+        val isRecruitingPost = Regex("""모집|신청""").containsMatchIn(contentText)
+        val listRangeIsApplyPeriod = listPeriod.isRange && isRecruitingPost
+        val detailDateTime = if (listRangeIsApplyPeriod) {
+            null
+        } else {
+            parseBestEventDateTime(contentLines, listPeriod.start)
+        }
+        val location = parseLocation(contentLines)
         val externalApplyLink = extractExternalApplyLink(doc)
         val imageUrl = extractImageUrl(doc) ?: listItem.imageUrl
         val attachments = extractAttachmentLinks(doc)
-        val tags = buildList {
-            if (attachments.isNotEmpty()) add("attachments:${attachments.size}")
-        }
+        val tags = emptyList<String>()
 
-        val activityStart = detailDateTime?.date ?: listPeriod.first
-        val activityEnd = detailDateTime?.date ?: listPeriod.second
+        val applyStart = if (listRangeIsApplyPeriod) listPeriod.start else null
+        val applyEnd = if (listRangeIsApplyPeriod) listPeriod.end else null
+        val activityStart = if (listRangeIsApplyPeriod) null else detailDateTime?.startDate ?: listPeriod.start
+        val activityEnd = if (listRangeIsApplyPeriod) null else detailDateTime?.endDate ?: listPeriod.end
         val session = if (activityStart != null || detailDateTime?.startTime != null || location != null) {
             CrawledDetailSession(
                 round = 1,
@@ -147,14 +159,13 @@ class SnuCalendarCrawler(
             ?.let { appendLinkSummary(it, externalApplyLink, attachments) }
 
         return CrawledProgramEvent(
-            dataSeq = "snu-calendar:${listItem.bbsidx}",
-            sourceUrl = sourceUrl,
+            dataSeq = listItem.bbsidx,
             applyLink = externalApplyLink ?: sourceUrl,
-            majorTypes = listOf("서울대학교"),
+            majorTypes = listOf("SNU 캘린더"),
             title = title,
-            status = null,
+            status = "상태 미제공",
             operationMode = null,
-            applyStart = null,
+            applyStart = applyStart,
             applyEnd = applyEnd,
             activityStart = activityStart,
             activityEnd = activityEnd,
@@ -207,15 +218,15 @@ class SnuCalendarCrawler(
     }
 
     private fun ListItem.toFallbackEvent(sourceUrl: String): CrawledProgramEvent {
-        val (start, end) = parseDotRangeToYmd(dateText)
+        val period = parseListDateRange(dateText)
         return CrawledProgramEvent(
-            dataSeq = "snu-calendar:$bbsidx",
-            sourceUrl = sourceUrl,
+            dataSeq = bbsidx,
             applyLink = sourceUrl,
-            majorTypes = listOf("서울대학교"),
+            majorTypes = listOf("SNU 캘린더"),
             title = title,
-            activityStart = start,
-            activityEnd = end,
+            status = "상태 미제공",
+            activityStart = period.start,
+            activityEnd = period.end,
             imageUrl = imageUrl,
             isPeriodEvent = false,
         )
@@ -278,40 +289,50 @@ class SnuCalendarCrawler(
         return "$html\n$extra"
     }
 
-    private fun parseLocation(text: String): String? {
-        val m = Regex("""(?:장소|위치)\s*[:：]\s*([^·\n\r]+?)(?=\s+(?:대상|제공|신청|일정|문의|상세|$))""")
-            .find(text)
-        return m?.groupValues?.get(1)?.normalize()?.takeIf { it.isNotBlank() }
+    private fun extractContentLines(content: Element?): List<String> {
+        val html = content?.html() ?: return emptyList()
+        return html
+            .replace(Regex("""(?i)<br\s*/?>"""), "\n")
+            .replace(Regex("""(?i)</(p|div|li|tr|h[1-6])>"""), "\n")
+            .lines()
+            .map { Jsoup.parse(it).text().normalize() }
+            .filter { it.isNotBlank() }
     }
 
-    private fun parseApplyEnd(text: String): String? {
-        val marker = Regex("""신청\s*마감\s*[:：]?\s*""").find(text) ?: return null
-        val tail = text.substring(marker.range.last + 1).take(80)
-        return parseKoreanDate(tail)?.date
-    }
-
-    private fun parseBestEventDateTime(text: String): ParsedDateTime? {
-        val marker = Regex("""(?:일정|일시|행사\s*일시)\s*[:：]?\s*""").find(text)
-        if (marker != null) {
-            val tail = text.substring(marker.range.last + 1).take(120)
-            parseKoreanDate(tail)?.let { return it }
+    private fun parseLocation(lines: List<String>): String? {
+        lines.forEach { line ->
+            if (!line.contains("장소")) return@forEach
+            parseLocationFromLine(line)?.let { return it }
         }
-        return Regex("""20\d{2}년\s*\d{1,2}월\s*\d{1,2}일.{0,40}""")
-            .findAll(text)
-            .mapNotNull { parseKoreanDate(it.value) }
-            .firstOrNull { it.startTime != null }
+        return null
     }
 
-    private fun parseKoreanDate(raw: String): ParsedDateTime? {
-        val dateMatch = Regex("""(20\d{2})년\s*(\d{1,2})월\s*(\d{1,2})일""").find(raw) ?: return null
-        val y = dateMatch.groupValues[1].toInt()
-        val m = dateMatch.groupValues[2].toInt()
-        val d = dateMatch.groupValues[3].toInt()
-        val date = runCatching { LocalDate.of(y, m, d).toString() }.getOrNull() ?: return null
-        val tail = raw.substring(dateMatch.range.last + 1).take(80)
-        val timeRange = parseTimeRange(tail)
+    private fun parseLocationFromLine(line: String): String? {
+        val m = Regex("""장소\s*[:：]?\s*(.+)$""").find(line) ?: return null
+        return m.groupValues[1].normalize().takeIf { it.isNotBlank() }
+    }
+
+    private fun parseBestEventDateTime(lines: List<String>, fallbackDate: String?): ParsedDateTime? {
+        val defaultDate = fallbackDate?.let { runCatching { LocalDate.parse(it) }.getOrNull() }
+        lines.forEachIndexed { index, line ->
+            if (!Regex("""시간|기간|일시|일정""").containsMatchIn(line)) return@forEachIndexed
+            val candidate = listOfNotNull(line, lines.getOrNull(index + 1))
+                .joinToString(" ")
+                .normalize()
+            parseDateTimeRange(candidate, defaultDate)?.let { return it }
+        }
+        return null
+    }
+
+    private fun parseDateTimeRange(raw: String, fallbackDate: LocalDate?): ParsedDateTime? {
+        val dates = extractDates(raw, fallbackDate)
+        if (dates.isEmpty()) return null
+        val startDate = dates.first()
+        val endDate = normalizeEndDate(startDate, dates.getOrNull(1), hasExplicitEndYear(raw)) ?: startDate
+        val timeRange = parseTimeRange(raw)
         return ParsedDateTime(
-            date = date,
+            startDate = startDate.toString(),
+            endDate = endDate.toString(),
             startTime = timeRange?.first,
             endTime = timeRange?.second,
         )
@@ -350,23 +371,61 @@ class SnuCalendarCrawler(
         return "%02d:%02d".format(hour, minute)
     }
 
-    private fun parseDotRangeToYmd(raw: String?): Pair<String?, String?> {
-        val dates = Regex("""(20\d{2})\.(\d{1,2})\.(\d{1,2})\.?""")
-            .findAll(raw.orEmpty())
-            .mapNotNull {
-                val y = it.groupValues[1].toInt()
-                val m = it.groupValues[2].toInt()
-                val d = it.groupValues[3].toInt()
-                runCatching { LocalDate.of(y, m, d).toString() }.getOrNull()
+    private fun parseListDateRange(raw: String?): ParsedListPeriod {
+        val dates = extractDates(raw.orEmpty(), fallbackDate = null)
+        val start = dates.firstOrNull()
+        val end = normalizeEndDate(start, dates.getOrNull(1), hasExplicitEndYear(raw.orEmpty())) ?: start
+        return ParsedListPeriod(
+            start = start?.toString(),
+            end = end?.toString(),
+            isRange = raw.orEmpty().contains("~") && start != null && end != null && start != end,
+        )
+    }
+
+    private fun extractDates(raw: String, fallbackDate: LocalDate?): List<LocalDate> {
+        val defaultYear = fallbackDate?.year ?: LocalDate.now().year
+        var previousMonth = fallbackDate?.monthValue
+        val currentMonth = LocalDate.now().monthValue
+
+        return dateTokenRegex.findAll(raw)
+            .mapNotNull { match ->
+                val yearGroup = match.groups["year"]?.value ?: match.groups["dotYear"]?.value
+                val monthGroup = match.groups["month"]?.value ?: match.groups["dotMonth"]?.value
+                val dayGroup = match.groups["day"]?.value ?: match.groups["dotDay"]?.value ?: return@mapNotNull null
+
+                val month = monthGroup?.toIntOrNull() ?: previousMonth ?: fallbackDate?.monthValue ?: return@mapNotNull null
+                val explicitYear = yearGroup?.toIntOrNull()
+                val year = explicitYear ?: inferYear(defaultYear, currentMonth, month)
+                val day = dayGroup.toIntOrNull() ?: return@mapNotNull null
+                previousMonth = month
+
+                runCatching { LocalDate.of(year, month, day) }.getOrNull()
             }
             .toList()
-        return dates.firstOrNull() to (dates.getOrNull(1) ?: dates.firstOrNull())
+    }
+
+    private fun inferYear(defaultYear: Int, currentMonth: Int, parsedMonth: Int): Int =
+        if (currentMonth == 12 && parsedMonth == 1) defaultYear + 1 else defaultYear
+
+    private fun normalizeEndDate(start: LocalDate?, end: LocalDate?, hasExplicitEndYear: Boolean): LocalDate? {
+        if (start == null || end == null) return end
+        if (end >= start || hasExplicitEndYear) return end
+        return runCatching { end.plusYears(1) }.getOrNull() ?: end
+    }
+
+    private fun hasExplicitEndYear(raw: String): Boolean {
+        val years = Regex("""20\d{2}""").findAll(raw).toList()
+        return years.size >= 2
     }
 
     private fun String.normalize(): String =
         replace("\u00a0", " ")
             .replace(Regex("""\s+"""), " ")
             .trim()
+
+    private val dateTokenRegex = Regex(
+        pattern = """(?:(?<year>20\d{2})\s*년\s*)?(?:(?<month>\d{1,2})\s*월\s*)?(?<day>\d{1,2})\s*일|(?:(?<dotYear>20\d{2})\s*[.]\s*)?(?<dotMonth>\d{1,2})\s*[./]\s*(?<dotDay>\d{1,2})\s*[.]?"""
+    )
 
     data class CrawlOptions(
         val startPage: Int,
@@ -390,8 +449,15 @@ class SnuCalendarCrawler(
     )
 
     private data class ParsedDateTime(
-        val date: String,
+        val startDate: String,
+        val endDate: String?,
         val startTime: String?,
         val endTime: String?,
+    )
+
+    private data class ParsedListPeriod(
+        val start: String?,
+        val end: String?,
+        val isRange: Boolean,
     )
 }

--- a/hangsha/batch/src/main/kotlin/com/team1/hangsha/batch/crawler/SnuCalendarCrawler.kt
+++ b/hangsha/batch/src/main/kotlin/com/team1/hangsha/batch/crawler/SnuCalendarCrawler.kt
@@ -173,7 +173,7 @@ class SnuCalendarCrawler(
             imageUrl = imageUrl,
             tags = tags,
             mainContentHtml = enrichedHtml,
-            isPeriodEvent = false,
+            isPeriodEvent = applyStart != null,
             detailSessions = listOfNotNull(session),
         )
     }

--- a/hangsha/batch/src/main/kotlin/com/team1/hangsha/batch/crawler/SnuCalendarCrawler.kt
+++ b/hangsha/batch/src/main/kotlin/com/team1/hangsha/batch/crawler/SnuCalendarCrawler.kt
@@ -133,7 +133,6 @@ class SnuCalendarCrawler(
             parseBestEventDateTime(contentLines, listPeriod.start)
         }
         val location = parseLocation(contentLines)
-        val externalApplyLink = extractExternalApplyLink(doc)
         val imageUrl = extractImageUrl(doc) ?: listItem.imageUrl
         val attachments = extractAttachmentLinks(doc)
         val tags = emptyList<String>()
@@ -156,11 +155,11 @@ class SnuCalendarCrawler(
         }
 
         val enrichedHtml = contentHtml
-            ?.let { appendLinkSummary(it, externalApplyLink, attachments) }
+            ?.let { appendLinkSummary(it, attachments) }
 
         return CrawledProgramEvent(
             dataSeq = listItem.bbsidx,
-            applyLink = externalApplyLink ?: sourceUrl,
+            applyLink = sourceUrl,
             majorTypes = listOf("SNU 캘린더"),
             title = title,
             status = "상태 미제공",
@@ -249,38 +248,15 @@ class SnuCalendarCrawler(
         }
     }
 
-    private fun extractExternalApplyLink(doc: Document): String? {
-        val anchors = doc.select(".board-view .content a[href]")
-        val formLink = anchors.firstOrNull { a ->
-            val href = a.absUrl("href")
-            href.contains("forms.gle") || href.contains("docs.google.com/forms")
-        }?.absUrl("href")?.takeIf { it.isNotBlank() }
-        if (formLink != null) return formLink
-
-        return anchors.firstOrNull { a ->
-            val nearby = buildString {
-                append(a.text())
-                append(" ")
-                append(a.parent()?.ownText().orEmpty())
-                append(" ")
-                append(a.previousSibling()?.toString().orEmpty().takeLast(40))
-            }.normalize()
-            nearby.contains("신청")
-        }?.absUrl("href")?.takeIf { it.isNotBlank() }
-    }
-
     private fun extractAttachmentLinks(doc: Document): List<String> =
         doc.select(".download a[href]")
             .mapNotNull { it.absUrl("href").takeIf { href -> href.isNotBlank() } }
             .distinct()
 
-    private fun appendLinkSummary(html: String, applyLink: String?, attachments: List<String>): String {
-        if (applyLink == null && attachments.isEmpty()) return html
+    private fun appendLinkSummary(html: String, attachments: List<String>): String {
+        if (attachments.isEmpty()) return html
         val extra = buildString {
             append("""<div class="snu-calendar-links">""")
-            if (applyLink != null) {
-                append("""<p><strong>신청 링크:</strong> <a href="$applyLink">$applyLink</a></p>""")
-            }
             attachments.forEach { link ->
                 append("""<p><strong>첨부 링크:</strong> <a href="$link">$link</a></p>""")
             }

--- a/hangsha/batch/src/main/kotlin/com/team1/hangsha/batch/crawler/SnuCalendarCrawler.kt
+++ b/hangsha/batch/src/main/kotlin/com/team1/hangsha/batch/crawler/SnuCalendarCrawler.kt
@@ -1,0 +1,397 @@
+package com.team1.hangsha.batch.crawler
+
+import com.team1.hangsha.event.dto.core.CrawledDetailSession
+import com.team1.hangsha.event.dto.core.CrawledProgramEvent
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import org.jsoup.nodes.Element
+import java.time.LocalDate
+import java.util.concurrent.TimeUnit
+
+class SnuCalendarCrawler(
+    private val baseUrl: String = "https://www.snu.ac.kr",
+    private val delayMsBetweenPages: Long = 200,
+    private val delayMsBetweenDetails: Long = 100,
+    private val debug: Boolean = true,
+    private val userAgent: String =
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36",
+    private val client: OkHttpClient = OkHttpClient.Builder()
+        .connectTimeout(10, TimeUnit.SECONDS)
+        .readTimeout(25, TimeUnit.SECONDS)
+        .callTimeout(40, TimeUnit.SECONDS)
+        .followRedirects(true)
+        .build(),
+) {
+    fun crawl(opt: CrawlOptions): List<CrawledProgramEvent> {
+        require(opt.maxPages > 0) { "maxPages must be positive" }
+        require(opt.startPage > 0) { "startPage must be positive" }
+
+        val result = mutableListOf<CrawledProgramEvent>()
+        val seenBbsidx = linkedSetOf<String>()
+        val lastPage = opt.startPage + opt.maxPages - 1
+
+        for (page in opt.startPage..lastPage) {
+            val listUrl = buildListUrl(
+                page = page,
+                df = opt.df,
+                dt = opt.dt,
+                qt = opt.qt,
+                q = opt.q,
+            )
+            val html = fetch(listUrl, referer = "$baseUrl/snunow/events") ?: break
+            val parsed = parseListHtml(html)
+
+            if (parsed.hasNoResultsMessage) {
+                if (debug) println("[SNU-CALENDAR] page=$page no-results message, stopping.")
+                break
+            }
+            if (parsed.items.isEmpty()) {
+                if (debug) println("[SNU-CALENDAR] page=$page no events, stopping.")
+                break
+            }
+
+            val newItems = parsed.items.filter { seenBbsidx.add(it.bbsidx) }
+            if (newItems.isEmpty()) {
+                if (debug) println("[SNU-CALENDAR] page=$page duplicate-only page, stopping.")
+                break
+            }
+
+            if (debug) println("[SNU-CALENDAR] page=$page listItems=${parsed.items.size} newItems=${newItems.size}")
+
+            newItems.forEach { item ->
+                val detailUrl = canonicalDetailUrl(item.bbsidx)
+                val detailHtml = fetch(detailUrl, referer = listUrl)
+                val event = if (detailHtml == null) {
+                    item.toFallbackEvent(detailUrl)
+                } else {
+                    parseDetailHtml(detailHtml, item, detailUrl)
+                }
+                result += event
+
+                if (delayMsBetweenDetails > 0) Thread.sleep(delayMsBetweenDetails)
+            }
+
+            if (delayMsBetweenPages > 0) Thread.sleep(delayMsBetweenPages)
+        }
+
+        return result
+    }
+
+    fun buildListUrl(page: Int, df: String? = null, dt: String? = null, qt: String? = null, q: String? = null): String {
+        val builder = "$baseUrl/snunow/events".toHttpUrl().newBuilder()
+        if (!df.isNullOrBlank() || !dt.isNullOrBlank()) {
+            builder.addQueryParameter("df", df.orEmpty())
+            builder.addQueryParameter("dt", dt.orEmpty())
+            builder.addQueryParameter("page", page.toString())
+            builder.addQueryParameter("qt", qt ?: "b")
+            builder.addQueryParameter("q", q.orEmpty())
+        } else {
+            builder.addQueryParameter("page", page.toString())
+        }
+        return builder.build().toString()
+    }
+
+    fun parseListHtml(html: String): ParsedListPage {
+        val doc = Jsoup.parse(html, baseUrl)
+        val hasNoResults = doc.text().normalize().contains("검색된 자료가 없습니다.")
+        if (hasNoResults) return ParsedListPage(hasNoResultsMessage = true, items = emptyList())
+
+        val items = doc.select(".board-imgline a.item[href*=bbsidx]")
+            .mapNotNull { parseListItem(it) }
+            .distinctBy { it.bbsidx }
+
+        return ParsedListPage(hasNoResultsMessage = false, items = items)
+    }
+
+    fun parseDetailHtml(html: String, listItem: ListItem, sourceUrl: String): CrawledProgramEvent {
+        val doc = Jsoup.parse(html, sourceUrl)
+        val content = doc.selectFirst(".board-view .content") ?: doc.selectFirst(".view .content")
+        val contentHtml = content?.html()?.trim()?.takeIf { it.isNotBlank() }
+        val contentText = content?.text()?.normalize().orEmpty()
+
+        val title = doc.selectFirst(".board-view .header .title")?.text()?.normalize()
+            ?: doc.selectFirst("meta[property=og:title]")?.attr("content")?.substringBefore(" - ")?.normalize()
+            ?: listItem.title
+        val listPeriod = parseDotRangeToYmd(
+            doc.selectFirst(".board-view .header .date")?.text()?.normalize() ?: listItem.dateText
+        )
+        val detailDateTime = parseBestEventDateTime(contentText)
+        val applyEnd = parseApplyEnd(contentText)
+        val location = parseLocation(contentText)
+        val externalApplyLink = extractExternalApplyLink(doc)
+        val imageUrl = extractImageUrl(doc) ?: listItem.imageUrl
+        val attachments = extractAttachmentLinks(doc)
+        val tags = buildList {
+            if (attachments.isNotEmpty()) add("attachments:${attachments.size}")
+        }
+
+        val activityStart = detailDateTime?.date ?: listPeriod.first
+        val activityEnd = detailDateTime?.date ?: listPeriod.second
+        val session = if (activityStart != null || detailDateTime?.startTime != null || location != null) {
+            CrawledDetailSession(
+                round = 1,
+                location = location,
+                startDate = activityStart,
+                endDate = activityEnd ?: activityStart,
+                startTime = detailDateTime?.startTime,
+                endTime = detailDateTime?.endTime,
+            )
+        } else {
+            null
+        }
+
+        val enrichedHtml = contentHtml
+            ?.let { appendLinkSummary(it, externalApplyLink, attachments) }
+
+        return CrawledProgramEvent(
+            dataSeq = "snu-calendar:${listItem.bbsidx}",
+            sourceUrl = sourceUrl,
+            applyLink = externalApplyLink ?: sourceUrl,
+            majorTypes = listOf("서울대학교"),
+            title = title,
+            status = null,
+            operationMode = null,
+            applyStart = null,
+            applyEnd = applyEnd,
+            activityStart = activityStart,
+            activityEnd = activityEnd,
+            applyCount = null,
+            capacity = null,
+            imageUrl = imageUrl,
+            tags = tags,
+            mainContentHtml = enrichedHtml,
+            isPeriodEvent = false,
+            detailSessions = listOfNotNull(session),
+        )
+    }
+
+    private fun fetch(url: String, referer: String): String? {
+        val request = Request.Builder()
+            .url(url)
+            .get()
+            .header("User-Agent", userAgent)
+            .header("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
+            .header("Accept-Language", "ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7")
+            .header("Referer", referer)
+            .build()
+
+        if (debug) println("[SNU-CALENDAR] GET $url")
+
+        return client.newCall(request).execute().use { resp ->
+            if (!resp.isSuccessful) {
+                if (debug) println("[SNU-CALENDAR] FAIL code=${resp.code} url=$url")
+                return@use null
+            }
+            resp.body?.string()
+        }
+    }
+
+    private fun parseListItem(a: Element): ListItem? {
+        val href = a.absUrl("href").ifBlank { a.attr("href") }
+        val bbsidx = Regex("""[?&]bbsidx=(\d+)""").find(href)?.groupValues?.get(1) ?: return null
+        val title = a.selectFirst(".texts .title")?.text()?.normalize()
+            ?: a.selectFirst(".title")?.text()?.normalize()
+            ?: return null
+        val dateText = a.selectFirst(".point")?.text()?.normalize()
+        val imageUrl = extractBackgroundImage(a.selectFirst(".thumb")?.attr("style").orEmpty())
+
+        return ListItem(
+            bbsidx = bbsidx,
+            title = title,
+            dateText = dateText,
+            imageUrl = imageUrl,
+        )
+    }
+
+    private fun ListItem.toFallbackEvent(sourceUrl: String): CrawledProgramEvent {
+        val (start, end) = parseDotRangeToYmd(dateText)
+        return CrawledProgramEvent(
+            dataSeq = "snu-calendar:$bbsidx",
+            sourceUrl = sourceUrl,
+            applyLink = sourceUrl,
+            majorTypes = listOf("서울대학교"),
+            title = title,
+            activityStart = start,
+            activityEnd = end,
+            imageUrl = imageUrl,
+            isPeriodEvent = false,
+        )
+    }
+
+    private fun canonicalDetailUrl(bbsidx: String): String =
+        "$baseUrl/snunow/events?md=v&bbsidx=$bbsidx"
+
+    private fun extractImageUrl(doc: Document): String? =
+        doc.selectFirst("meta[property=og:image]")?.attr("content")?.takeIf { it.isNotBlank() }
+
+    private fun extractBackgroundImage(style: String): String? {
+        val raw = Regex("""url\((['"]?)(.*?)\1\)""").find(style)?.groupValues?.get(2)?.trim()
+            ?.takeIf { it.isNotBlank() }
+            ?: return null
+        return when {
+            raw.startsWith("http://") || raw.startsWith("https://") -> raw
+            raw.startsWith("/") -> "$baseUrl$raw"
+            else -> "$baseUrl/$raw"
+        }
+    }
+
+    private fun extractExternalApplyLink(doc: Document): String? {
+        val anchors = doc.select(".board-view .content a[href]")
+        val formLink = anchors.firstOrNull { a ->
+            val href = a.absUrl("href")
+            href.contains("forms.gle") || href.contains("docs.google.com/forms")
+        }?.absUrl("href")?.takeIf { it.isNotBlank() }
+        if (formLink != null) return formLink
+
+        return anchors.firstOrNull { a ->
+            val nearby = buildString {
+                append(a.text())
+                append(" ")
+                append(a.parent()?.ownText().orEmpty())
+                append(" ")
+                append(a.previousSibling()?.toString().orEmpty().takeLast(40))
+            }.normalize()
+            nearby.contains("신청")
+        }?.absUrl("href")?.takeIf { it.isNotBlank() }
+    }
+
+    private fun extractAttachmentLinks(doc: Document): List<String> =
+        doc.select(".download a[href]")
+            .mapNotNull { it.absUrl("href").takeIf { href -> href.isNotBlank() } }
+            .distinct()
+
+    private fun appendLinkSummary(html: String, applyLink: String?, attachments: List<String>): String {
+        if (applyLink == null && attachments.isEmpty()) return html
+        val extra = buildString {
+            append("""<div class="snu-calendar-links">""")
+            if (applyLink != null) {
+                append("""<p><strong>신청 링크:</strong> <a href="$applyLink">$applyLink</a></p>""")
+            }
+            attachments.forEach { link ->
+                append("""<p><strong>첨부 링크:</strong> <a href="$link">$link</a></p>""")
+            }
+            append("</div>")
+        }
+        return "$html\n$extra"
+    }
+
+    private fun parseLocation(text: String): String? {
+        val m = Regex("""(?:장소|위치)\s*[:：]\s*([^·\n\r]+?)(?=\s+(?:대상|제공|신청|일정|문의|상세|$))""")
+            .find(text)
+        return m?.groupValues?.get(1)?.normalize()?.takeIf { it.isNotBlank() }
+    }
+
+    private fun parseApplyEnd(text: String): String? {
+        val marker = Regex("""신청\s*마감\s*[:：]?\s*""").find(text) ?: return null
+        val tail = text.substring(marker.range.last + 1).take(80)
+        return parseKoreanDate(tail)?.date
+    }
+
+    private fun parseBestEventDateTime(text: String): ParsedDateTime? {
+        val marker = Regex("""(?:일정|일시|행사\s*일시)\s*[:：]?\s*""").find(text)
+        if (marker != null) {
+            val tail = text.substring(marker.range.last + 1).take(120)
+            parseKoreanDate(tail)?.let { return it }
+        }
+        return Regex("""20\d{2}년\s*\d{1,2}월\s*\d{1,2}일.{0,40}""")
+            .findAll(text)
+            .mapNotNull { parseKoreanDate(it.value) }
+            .firstOrNull { it.startTime != null }
+    }
+
+    private fun parseKoreanDate(raw: String): ParsedDateTime? {
+        val dateMatch = Regex("""(20\d{2})년\s*(\d{1,2})월\s*(\d{1,2})일""").find(raw) ?: return null
+        val y = dateMatch.groupValues[1].toInt()
+        val m = dateMatch.groupValues[2].toInt()
+        val d = dateMatch.groupValues[3].toInt()
+        val date = runCatching { LocalDate.of(y, m, d).toString() }.getOrNull() ?: return null
+        val tail = raw.substring(dateMatch.range.last + 1).take(80)
+        val timeRange = parseTimeRange(tail)
+        return ParsedDateTime(
+            date = date,
+            startTime = timeRange?.first,
+            endTime = timeRange?.second,
+        )
+    }
+
+    private fun parseTimeRange(raw: String): Pair<String?, String?>? {
+        val s = raw.normalize()
+        val colonRange = Regex("""(\d{1,2}):(\d{2})\s*(?:-|–|~)\s*(\d{1,2}):(\d{2})""").find(s)
+        if (colonRange != null) {
+            val start = formatTime(colonRange.groupValues[1].toInt(), colonRange.groupValues[2].toInt())
+            val end = formatTime(colonRange.groupValues[3].toInt(), colonRange.groupValues[4].toInt())
+            return start to end
+        }
+
+        val singleColon = Regex("""(\d{1,2}):(\d{2})""").find(s)
+        if (singleColon != null) {
+            return formatTime(singleColon.groupValues[1].toInt(), singleColon.groupValues[2].toInt()) to null
+        }
+
+        val koreanTime = Regex("""(오전|오후)?\s*(\d{1,2})시(?:\s*(\d{1,2})분)?""").find(s)
+            ?: return null
+        val ampm = koreanTime.groupValues[1].takeIf { it.isNotBlank() }
+        val hour = koreanTime.groupValues[2].toInt().let {
+            when {
+                ampm == "오후" && it < 12 -> it + 12
+                ampm == "오전" && it == 12 -> 0
+                else -> it
+            }
+        }
+        val minute = koreanTime.groupValues[3].takeIf { it.isNotBlank() }?.toInt() ?: 0
+        return formatTime(hour, minute) to null
+    }
+
+    private fun formatTime(hour: Int, minute: Int): String? {
+        if (hour !in 0..23 || minute !in 0..59) return null
+        return "%02d:%02d".format(hour, minute)
+    }
+
+    private fun parseDotRangeToYmd(raw: String?): Pair<String?, String?> {
+        val dates = Regex("""(20\d{2})\.(\d{1,2})\.(\d{1,2})\.?""")
+            .findAll(raw.orEmpty())
+            .mapNotNull {
+                val y = it.groupValues[1].toInt()
+                val m = it.groupValues[2].toInt()
+                val d = it.groupValues[3].toInt()
+                runCatching { LocalDate.of(y, m, d).toString() }.getOrNull()
+            }
+            .toList()
+        return dates.firstOrNull() to (dates.getOrNull(1) ?: dates.firstOrNull())
+    }
+
+    private fun String.normalize(): String =
+        replace("\u00a0", " ")
+            .replace(Regex("""\s+"""), " ")
+            .trim()
+
+    data class CrawlOptions(
+        val startPage: Int,
+        val maxPages: Int,
+        val df: String? = null,
+        val dt: String? = null,
+        val qt: String? = null,
+        val q: String? = null,
+    )
+
+    data class ParsedListPage(
+        val hasNoResultsMessage: Boolean,
+        val items: List<ListItem>,
+    )
+
+    data class ListItem(
+        val bbsidx: String,
+        val title: String,
+        val dateText: String?,
+        val imageUrl: String?,
+    )
+
+    private data class ParsedDateTime(
+        val date: String,
+        val startTime: String?,
+        val endTime: String?,
+    )
+}

--- a/hangsha/batch/src/main/kotlin/com/team1/hangsha/batch/job/ExtraSnuSyncRunner.kt
+++ b/hangsha/batch/src/main/kotlin/com/team1/hangsha/batch/job/ExtraSnuSyncRunner.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.team1.hangsha.batch.crawler.DetailSession
 import com.team1.hangsha.batch.crawler.ExtraSnuCrawler
 import com.team1.hangsha.batch.crawler.ProgramEvent
+import com.team1.hangsha.batch.crawler.SnuCalendarCrawler
 import com.team1.hangsha.common.upload.OciUploadService
 import com.team1.hangsha.config.DatabaseConfig
 import com.team1.hangsha.config.OciConfig
@@ -94,6 +95,36 @@ class ExtraSnuSyncRunner(
             }
         }
 
+        if (opt.withSnuCalendar) {
+            val snuCalendarEvents = SnuCalendarCrawler(
+                delayMsBetweenPages = opt.delayMs,
+                delayMsBetweenDetails = opt.detailDelayMs,
+            ).crawl(
+                SnuCalendarCrawler.CrawlOptions(
+                    startPage = opt.snuCalendarStartPage,
+                    maxPages = opt.snuCalendarMaxPages,
+                )
+            )
+
+            if (opt.outFile != null) {
+                dumpBuffer += snuCalendarEvents
+            }
+
+            totalCrawled += snuCalendarEvents.size
+            if (opt.dumpOnly) {
+                println("SNU calendar crawled: total=${snuCalendarEvents.size}")
+            } else {
+                val result = eventSyncService.sync(snuCalendarEvents)
+                totalUpserted += result.upserted
+                totalSkipped += result.skipped
+
+                println(
+                    "SNU calendar synced: upserted=${result.upserted}, " +
+                            "total=${result.total}, skipped=${result.skipped}"
+                )
+            }
+        }
+
         if (opt.outFile != null) {
             writeDumpFile(opt.outFile, dumpBuffer)
             println("Saved crawled events to ${opt.outFile} (count=${dumpBuffer.size})")
@@ -127,6 +158,9 @@ private data class BatchArgs(
     val detailDelayMs: Long = 100,
     val outFile: String? = null,
     val dumpOnly: Boolean = false,
+    val withSnuCalendar: Boolean = true,
+    val snuCalendarStartPage: Int = 1,
+    val snuCalendarMaxPages: Int = 4,
 ) {
     companion object {
         fun from(args: ApplicationArguments): BatchArgs {
@@ -146,6 +180,9 @@ private data class BatchArgs(
                 detailDelayMs = single("detailDelayMs")?.toLong() ?: 100L,
                 outFile = single("outFile"),
                 dumpOnly = args.containsOption("dumpOnly"),
+                withSnuCalendar = !args.containsOption("noSnuCalendar"),
+                snuCalendarStartPage = single("snuCalendarStartPage")?.toInt() ?: 1,
+                snuCalendarMaxPages = single("snuCalendarMaxPages")?.toInt() ?: 4,
             )
         }
     }

--- a/hangsha/batch/src/main/kotlin/com/team1/hangsha/batch/job/ExtraSnuSyncRunner.kt
+++ b/hangsha/batch/src/main/kotlin/com/team1/hangsha/batch/job/ExtraSnuSyncRunner.kt
@@ -184,7 +184,6 @@ private fun ProgramEvent.toCrawledProgramEvent(): CrawledProgramEvent {
 
     return CrawledProgramEvent(
         dataSeq = dataSeq,
-        sourceUrl = dataSeq?.let { "https://extra.snu.ac.kr/ptfol/pgm/view.do?dataSeq=$it" },
         applyLink = dataSeq?.let { "https://extra.snu.ac.kr/ptfol/pgm/view.do?dataSeq=$it" },
         majorTypes = majorTypes,
         title = title,

--- a/hangsha/batch/src/main/kotlin/com/team1/hangsha/batch/job/ExtraSnuSyncRunner.kt
+++ b/hangsha/batch/src/main/kotlin/com/team1/hangsha/batch/job/ExtraSnuSyncRunner.kt
@@ -5,12 +5,18 @@ import com.team1.hangsha.batch.crawler.DetailSession
 import com.team1.hangsha.batch.crawler.ExtraSnuCrawler
 import com.team1.hangsha.batch.crawler.ProgramEvent
 import com.team1.hangsha.common.upload.OciUploadService
+import com.team1.hangsha.config.DatabaseConfig
+import com.team1.hangsha.config.OciConfig
+import com.team1.hangsha.config.TestValueLogger
 import com.team1.hangsha.event.dto.core.CrawledDetailSession
 import com.team1.hangsha.event.dto.core.CrawledProgramEvent
 import com.team1.hangsha.event.model.EventPeriodPolicy
 import com.team1.hangsha.event.service.EventSyncService
 import org.springframework.boot.ApplicationArguments
 import org.springframework.boot.ApplicationRunner
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Import
 import org.springframework.stereotype.Component
 import java.nio.file.Files
 import java.nio.file.Path
@@ -18,6 +24,7 @@ import java.time.LocalDate
 import kotlin.system.exitProcess
 
 @Component
+@ConditionalOnProperty(name = ["job"], havingValue = "extra-snu-sync", matchIfMissing = true)
 class ExtraSnuSyncRunner(
     private val eventSyncService: EventSyncService,
     private val ociUploadService: OciUploadService,
@@ -25,6 +32,11 @@ class ExtraSnuSyncRunner(
 ) : ApplicationRunner {
 
     override fun run(args: ApplicationArguments) {
+        val job = args.getOptionValues("job")?.firstOrNull()
+        if (job != null && job != "extra-snu-sync") {
+            return
+        }
+
         val opt = BatchArgs.from(args)
 
         val applyChkCodes = listOf("0001", "0002", "0003", "0004")
@@ -156,11 +168,24 @@ private fun ProgramEvent.isPeriodEventFromList(): Boolean {
     )
 }
 
+@Configuration
+@ConditionalOnProperty(name = ["job"], havingValue = "extra-snu-sync", matchIfMissing = true)
+@Import(
+    DatabaseConfig::class,
+    EventSyncService::class,
+    TestValueLogger::class,
+    OciConfig::class,
+    OciUploadService::class,
+)
+class ExtraSnuSyncConfiguration
+
 private fun ProgramEvent.toCrawledProgramEvent(): CrawledProgramEvent {
     val isPeriodEvent = isPeriodEventFromList()
 
     return CrawledProgramEvent(
         dataSeq = dataSeq,
+        sourceUrl = dataSeq?.let { "https://extra.snu.ac.kr/ptfol/pgm/view.do?dataSeq=$it" },
+        applyLink = dataSeq?.let { "https://extra.snu.ac.kr/ptfol/pgm/view.do?dataSeq=$it" },
         majorTypes = majorTypes,
         title = title,
         status = status,

--- a/hangsha/batch/src/main/kotlin/com/team1/hangsha/batch/job/SnuCalendarDumpRunner.kt
+++ b/hangsha/batch/src/main/kotlin/com/team1/hangsha/batch/job/SnuCalendarDumpRunner.kt
@@ -1,0 +1,81 @@
+package com.team1.hangsha.batch.job
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.team1.hangsha.batch.crawler.SnuCalendarCrawler
+import com.team1.hangsha.event.dto.core.CrawledProgramEvent
+import org.springframework.boot.ApplicationArguments
+import org.springframework.boot.ApplicationRunner
+import org.springframework.stereotype.Component
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.system.exitProcess
+
+@Component
+class SnuCalendarDumpRunner(
+    private val objectMapper: ObjectMapper,
+) : ApplicationRunner {
+    override fun run(args: ApplicationArguments) {
+        if (args.getOptionValues("job")?.firstOrNull() != "snu-calendar-dump") {
+            return
+        }
+
+        val opt = SnuCalendarDumpArgs.from(args)
+        val rows = SnuCalendarCrawler(
+            delayMsBetweenPages = opt.delayMs,
+            delayMsBetweenDetails = opt.detailDelayMs,
+        ).crawl(
+            SnuCalendarCrawler.CrawlOptions(
+                startPage = opt.startPage,
+                maxPages = opt.maxPages,
+                df = opt.df,
+                dt = opt.dt,
+                qt = opt.qt,
+                q = opt.q,
+            )
+        )
+
+        writeDumpFile(opt.outFile, rows)
+        println("Saved SNU calendar events to ${Path.of(opt.outFile).toAbsolutePath().normalize()} (count=${rows.size})")
+        exitProcess(0)
+    }
+
+    private fun writeDumpFile(outFile: String, rows: List<CrawledProgramEvent>) {
+        val path = Path.of(outFile).toAbsolutePath().normalize()
+        path.parent?.let { Files.createDirectories(it) }
+        objectMapper.writerWithDefaultPrettyPrinter().writeValue(path.toFile(), rows)
+    }
+}
+
+private data class SnuCalendarDumpArgs(
+    val startPage: Int,
+    val maxPages: Int,
+    val df: String?,
+    val dt: String?,
+    val qt: String?,
+    val q: String?,
+    val delayMs: Long,
+    val detailDelayMs: Long,
+    val outFile: String,
+) {
+    companion object {
+        fun from(args: ApplicationArguments): SnuCalendarDumpArgs {
+            fun single(name: String): String? = args.getOptionValues(name)?.firstOrNull()
+
+            val maxPages = single("maxPages")?.toIntOrNull()
+                ?: throw IllegalArgumentException("--maxPages is required")
+            require(maxPages > 0) { "--maxPages must be positive" }
+
+            return SnuCalendarDumpArgs(
+                startPage = single("startPage")?.toIntOrNull() ?: 1,
+                maxPages = maxPages,
+                df = single("df"),
+                dt = single("dt"),
+                qt = single("qt"),
+                q = single("q"),
+                delayMs = single("delayMs")?.toLongOrNull() ?: 200L,
+                detailDelayMs = single("detailDelayMs")?.toLongOrNull() ?: 100L,
+                outFile = single("outFile") ?: "build/snu-calendar-events.json",
+            )
+        }
+    }
+}

--- a/hangsha/common/src/main/kotlin/com/team1/hangsha/event/dto/core/CrawledDtos.kt
+++ b/hangsha/common/src/main/kotlin/com/team1/hangsha/event/dto/core/CrawledDtos.kt
@@ -1,9 +1,12 @@
 package com.team1.hangsha.event.dto.core
 
+import com.fasterxml.jackson.annotation.JsonInclude
+
 // events.json을 그대로 받는 DTO
 
 data class CrawledProgramEvent(
     val dataSeq: String? = null,
+    @get:JsonInclude(JsonInclude.Include.NON_NULL)
     val sourceUrl: String? = null,
     val applyLink: String? = null,
     val majorTypes: List<String> = emptyList(), // [org, eventType]

--- a/hangsha/common/src/main/kotlin/com/team1/hangsha/event/dto/core/CrawledDtos.kt
+++ b/hangsha/common/src/main/kotlin/com/team1/hangsha/event/dto/core/CrawledDtos.kt
@@ -4,6 +4,8 @@ package com.team1.hangsha.event.dto.core
 
 data class CrawledProgramEvent(
     val dataSeq: String? = null,
+    val sourceUrl: String? = null,
+    val applyLink: String? = null,
     val majorTypes: List<String> = emptyList(), // [org, eventType]
     val title: String? = null,
     val status: String? = null,

--- a/hangsha/common/src/main/kotlin/com/team1/hangsha/event/service/EventSyncService.kt
+++ b/hangsha/common/src/main/kotlin/com/team1/hangsha/event/service/EventSyncService.kt
@@ -46,7 +46,7 @@ class EventSyncService(
         var skipped = 0
 
         for (e in events) {
-            val applyLink = "https://extra.snu.ac.kr/ptfol/pgm/view.do?dataSeq=${e.dataSeq}"
+            val applyLink = resolveApplyLink(e)
 
             // If we want to skip re-sync of deleted events, uncomment this block
             //if (eventRepository.existsAdminDeletedByApplyLink(applyLink)) {
@@ -222,6 +222,17 @@ class EventSyncService(
 
     private fun findCategoryId(groupId: Long, name: String): Long? =
         categoryRepository.findByGroupIdAndName(groupId, name)?.id
+
+    private fun resolveApplyLink(e: CrawledProgramEvent): String {
+        e.applyLink?.trim()?.takeIf { it.isNotBlank() }?.let { return it }
+
+        val dataSeq = e.dataSeq?.trim().orEmpty()
+        return if (dataSeq.length == 6 && dataSeq.all { it.isDigit() }) {
+            "https://www.snu.ac.kr/snunow/events?md=v&bbsidx=$dataSeq"
+        } else {
+            "https://extra.snu.ac.kr/ptfol/pgm/view.do?dataSeq=$dataSeq"
+        }
+    }
 
     private fun deriveEventPeriodAndLocation(
         e: CrawledProgramEvent,

--- a/hangsha/src/main/resources/db/migration/V27__add_unknown_recruitment_status.sql
+++ b/hangsha/src/main/resources/db/migration/V27__add_unknown_recruitment_status.sql
@@ -1,0 +1,10 @@
+INSERT INTO categories (group_id, name, sort_order)
+SELECT cg.id, '상태 미제공', 999
+FROM category_groups cg
+WHERE cg.name = '모집현황'
+  AND NOT EXISTS (
+      SELECT 1
+      FROM categories c
+      WHERE c.group_id = cg.id
+        AND c.name = '상태 미제공'
+  );


### PR DESCRIPTION
## 데이터 예시
{
  "dataSeq" : "172232",
  "applyLink" : "https://www.snu.ac.kr/snunow/events?md=v&bbsidx=172232",
  "majorTypes" : [ "SNU 캘린더" ],
  "title" : "[경력개발센터]국가포스닥펠로우십 및 국가과학AI연구센터 채용설명회(7/1) 안내",
  "status" : "상태 미제공",
  "operationMode" : null,
  "applyStart" : null,
  "applyEnd" : null,
  "activityStart" : "2026-07-01",
  "activityEnd" : "2026-07-01",
  "applyCount" : null,
  "capacity" : null,
  "imageUrl" : "https://www.snu.ac.kr/webdata/site/kor/config/840z2e9zd32zfccz0b8zc25z9c2z58cz84dz2a8z63.png",
  "tags" : [ ],
  "mainContentHtml" : "<p><span>국가전략기술 분야를 이끌어갈 우수 박사후연구원 양성을 위한 국가포스닥펠로우십(NPF) 설명회와 국가과학AI연구센터 정규직 연구원/기술원 채용설명회를 개최합니다.</span><br><br><span>많은 관심과 참여를 바랍니다.</span><br><br><br><img data-emoji=\"\uD83D\uDCC5\" alt=\"\uD83D\uDCC5\" aria-label=\"\uD83D\uDCC5\" draggable=\"false\" src=\"https://fonts.gstatic.com/s/e/notoemoji/17.0/1f4c5/32.png\" loading=\"lazy\"><span>&nbsp;일시 : 2026. 7. 1.(수) 14:30~15:30</span><br><br><img data-emoji=\"\uD83D\uDCCD\" alt=\"\uD83D\uDCCD\" aria-label=\"\uD83D\uDCCD\" draggable=\"false\" src=\"https://fonts.gstatic.com/s/e/notoemoji/17.0/1f4cd/32.png\" loading=\"lazy\"><span>&nbsp;장소 : 서울대학교 공학관 301동 118호</span><br><br><img data-emoji=\"\uD83D\uDC65\" alt=\"\uD83D\uDC65\" aria-label=\"\uD83D\uDC65\" draggable=\"false\" src=\"https://fonts.gstatic.com/s/e/notoemoji/17.0/1f465/32.png\" loading=\"lazy\"><span>&nbsp;대상 : (국가포스닥펠로우십) 박사과정생, 박사학위자(졸업예정자), 박사후연구원 및 연구 진로에 관심 있는 대학원생</span><br><br><span>(국가과학AI연구센터) 연구직 - 석사학위자(예정자) 이상, 기술직 - 학력무관</span><br><br><img data-emoji=\"\uD83D\uDC65\" alt=\"\uD83D\uDC65\" aria-label=\"\uD83D\uDC65\" draggable=\"false\" src=\"https://fonts.gstatic.com/s/e/notoemoji/17.0/1f465/32.png\" loading=\"lazy\"><span>&nbsp;사전신청링크:&nbsp;</span><a href=\"https://moaform.com/q/8kgsPq\" target=\"_blank\" data-saferedirecturl=\"https://www.google.com/url?q=https://moaform.com/q/8kgsPq&amp;source=gmail&amp;ust=1782781846614000&amp;usg=AOvVaw1eGnYcPnzggEJbbh0sAHBf\" rel=\"noopener noreferrer\" title=\"새창으로 열림\">https://moaform.com/q/8kgsPq</a><br><br><br><br><img data-emoji=\"\uD83D\uDCCC\" alt=\"\uD83D\uDCCC\" aria-label=\"\uD83D\uDCCC\" draggable=\"false\" src=\"https://fonts.gstatic.com/s/e/notoemoji/17.0/1f4cc/32.png\" loading=\"lazy\"><span>&nbsp;주요 내용</span><br><br><span>국가포스닥펠로우십 사업 소개</span><br><span>국가과학AI연구센터 소개 및 채용계획</span><br><span>출연연 연구과제 및 연구환경 안내</span><br><span>지원 자격 및 선발 절차 안내</span><br><span>연구 지원 및 진로 연계 안내</span><br><span>질의응답(Q&amp;A)</span><br><img data-emoji=\"\uD83E\uDD6A\" alt=\"\uD83E\uDD6A\" aria-label=\"\uD83E\uDD6A\" draggable=\"false\" src=\"https://fonts.gstatic.com/s/e/notoemoji/17.0/1f96a/32.png\" loading=\"lazy\"><span>&nbsp;참여자 대상 중식 제공</span><br><br><span>설명회 참석자에게 샌드위치 등 간단한 중식을 제공합니다.</span></p>",
  "isPeriodEvent" : false,
  "detailSessions" : [ {
    "round" : 1,
    "location" : "서울대학교 공학관 301동 118호",
    "startDate" : "2026-07-01",
    "endDate" : "2026-07-01",
    "startTime" : "14:30",
    "endTime" : "15:30"
  } ]
}

## 고려한 크롤링 정책

### 간단한 것
1. organizaton : 주최 기관인데, 일단 "SNU 캘린더"로 설정 (상세 페이지 html에서, 현재 DB에 있는 organization에 해당하는 단어가 혹시 들어가 있는지 linear search를 한 다음에, hit가 있으면 그 기관으로 설정하기?)
2. category : 이건 html에 없고 semantic하게 알 수 있는 거라 어쩔 수 없이 null 구현 (나중에 regex rule based로 같은 키워드가 있다면 들어가게 하는 것도 가능하긴 한데...)
3. status : 애초에 "신청"이라는 개념이 없으므로, state를 알 수 없음. (마찬가지로 semantic하게는 될 수도...?) 다만 null로 하면 필터링이 불가능한 문제 존재 --> 아예 스키마에 "상태 미제공"이라는 status 추가
4. operationMode : 원래 크롤링해오고 있었긴 한데, 지금 보니까 프론트에서 안 쓰고 있어서 null로 구현. (온/오프라인 여부)
5. capacity, applyCount, tags : 이건 확실히 전부 null로 구현해도 OK. 
6. -> 나중에 구현할 추가 아이디어: 사람이 읽으면 semantic하게 알 수 있는 것들 (organization, category, status) 의 경우에는 간단한 AI 파싱을 도입해볼 수 있긴 할듯... (쉽지는 않을 것 같지만: AI용 서버도 따로 구축해야 하고 등등...) -> 근데 사실 AI 파싱을 도입할 거면, 밑의 "까다로운 영역(특히 시간, 장소)"의 문제도 그냥 AI한테 맡기면 되기는 하는데...?

### 까다로운 영역
1. dataSeq : 지금 가져오는 snunow 사이트의 상세 페이지 형식은 이러함:
   https://www.snu.ac.kr/snunow/events?md=v&bbsidx=171821
   -> bbsidx 값을 그냥 저장하면 될 것이라고 생각했는데,
   원래는 dataSeq 값을 저장하고 실제 사이트로 가는 링크는 조합해서 주는 구조라 저것만 저장하면 호환이 안 될듯?
   그래도 구조는 정해져있으니까, applyLink 만들 때 6자리 수면 snunow 링크를 만들고, 그게 아니면 기존에 하던대로 하고.. 이런 정책이면 될듯
   (지금 굳이 저장할 때 snu-calendar 같은 prefix를 붙일 필요 전혀 없음)
    -> 그냥 EventSyncService.sync()에서 applyLink 만들 때 if문 하나만 추가하기. 이때 실제로 DB에 들어가는 거니까.
    굳이 추가 DB 수정을 하지 않기 위함. 암묵적인 규칙. 

2. apply/event period : regex를 활용한 상세 페이지 html 파싱으로는 신청/실제 행사 기간 둘다 잡기 어려움.
   다만, 목록 페이지에 있는 해당 행사의 시간을 고려할 수 있음.
   2026.06.23.(화) ~ 2026.07.13.(월)과 같이, ~가 들어가 있다면 (즉, 행사 기간이 여러 날에 걸쳐있다면) 그 날짜는 모집 기간일 확률이 매우 높음. 다만, 상세 페이지 본문에 "모집" 혹은 "신청"이라는 키워드가 없다면 진짜 event period가 여러 날에 걸쳐있는 것임.
   -> 따라서, 목록 페이지의 시간에 "~"가 있을 경우: 1) 상세 페이지 본문에 "모집" "신청"이 있다면 apply period로 저장, 2) 없다면 event period로 저장
   목록 페이지의 시간에 "~"가 없을 경우(즉, 하루만 열리는 행사): event period로 저장.

1. 목록 기간이 단일 날짜면 기본적으로 event period
2. 목록 기간이 range이고 본문에 "모집|신청"이 있으면 apply period
3. 목록 기간이 range이고 키워드가 없으면 event period
4. 상세 본문에서 더 명확한 시간이 잡히면 event period를 그 값으로 보정 (apply period 보정까지 고려하는 건 어려움)

그렇다면 상세 시간은?:
(만약 event period가 필요한 행사라면 상세 시간 수집 but apply period가 있으면 수집 안해도 됨, 애초에 프론트에서도 그 경우의 event period는 중요하게 안 다룸)
상세 페이지의 "시간" or "기간" or "일시"가 있는 행(키워드 ~ \n)에서 다음과 같은 패턴 검사하면 가능.

- 6월 22일(월) 18:10
- 2026년 7월 2일(목) 오전 10시
- 2026. 7. 1.(수) 14:30~15:30 
- 7/3 (금) 13:00 - 16:00 
- 2026.7.21.(화)~7.23.(목)
- 2026년 06월 18일(목) - 2026년 06월 19일(금) 10:00 ~ 18:00
- 2026년 6월 29일(월) ~ 30일(화)

예) 시간: 6월 22일(월) 18:10 \n -> "시간"이라는 키워드가 있는 line에 regex를 적용해 6. 22. 18:10 라는 값을 뽑을 수 있음.

연도의 경우는 파싱하지 말고, 일단 "현재 시간의 연도"에 따르도록 함.
현재 시간 연도는 12월인데 행사는 1월을 말하고 있는 경우, 12.x ~ 1.x와 같은 특별한 경우만 에러 핸들링을 하면 될듯. 

3. location : 위의 상세 시간과 비슷하게, "장소"라는 키워드가 있는 행 검사하면 됨.
   장소 : ~ \n 의 경우가 대부분이므로, 장소 혹은 장소: 부터 \n까지의 값을 regex를 사용해서 그대로 긁어오기.
   (추가 fallback 대응은 불필요함. 여러 개 확인해보니까 장소가 명시되어 있으면 무조건 장소라는 키워드를 사용함. 없으면 그냥 null)

4. 기존에 크롤링하던 비교과 행사 사이트와 겹치는 행사
   -> 상세 페이지에 "비교과"라는 단어가 언급되면 크롤링 or 저장 스킵.
   (비교과로 신청하세요~ 라는 거면 무조건 원래 크롤링하던 사이트에 존재한다는 뜻)

5. image 링크: 기존 사이트와 다르게, 이 사이트의 경우 전부 static이므로 서버에 업로드하는 로직 거칠 필요 없음. 그냥 그대로 저장하면 됨.
