### PR TITLE
fix: prevent saving blank memos and tags

### DIFF
--- a/hangsha/common/src/main/kotlin/com/team1/hangsha/common/error/ErrorCode.kt
+++ b/hangsha/common/src/main/kotlin/com/team1/hangsha/common/error/ErrorCode.kt
@@ -41,9 +41,11 @@ enum class ErrorCode(
     // Tag
     TAG_NOT_FOUND(HttpStatus.NOT_FOUND, "태그를 찾을 수 없습니다"),
     TAG_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 태그 이름입니다"),
+    TAG_NAME_CANNOT_BE_BLANK(HttpStatus.BAD_REQUEST, "태그 이름은 비워둘 수 없습니다"),
 
     // Memo
     MEMO_NOT_FOUND(HttpStatus.NOT_FOUND, "메모를 찾을 수 없습니다"),
+    MEMO_CONTENT_CANNOT_BE_BLANK(HttpStatus.BAD_REQUEST, "메모 내용은 비워둘 수 없습니다"),
 
     // Timetable / Enroll / Course
     TIMETABLE_NOT_FOUND(HttpStatus.NOT_FOUND, "시간표를 찾을 수 없습니다"),

--- a/hangsha/src/main/kotlin/com/team1/hangsha/memo/service/MemoService.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/memo/service/MemoService.kt
@@ -26,6 +26,8 @@ class MemoService(
 
     @Transactional
     fun createMemo(userId: Long, req: CreateMemoRequest): MemoResponse {
+        validateMemoContent(req.content)
+
         val event = eventRepository.findById(req.eventId)
             .orElseThrow { DomainException(ErrorCode.EVENT_NOT_FOUND) }
 
@@ -68,13 +70,13 @@ class MemoService(
             throw DomainException(ErrorCode.INVALID_REQUEST, "Invalid request body")
         }
 
-        // -------- content 정책: 미포함=변경없음 / null=비우기 / 값=업데이트 --------
+        // -------- content 정책: 미포함=변경없음 / null 또는 blank=거부 / 값=업데이트 --------
         val nextContent: String =
             if (!hasContent) {
                 memo.content
             } else {
-                // null이면 비우기 의도
-                (req.content ?: "").trimEnd() // trim 정책이 필요 없으면 그냥 (req.content ?: "")
+                validateMemoContent(req.content)
+                req.content!!.trimEnd()
             }
 
         // -------- tagNames 정책: 미포함=변경없음 / null=비우기 / 값=replace-all --------
@@ -173,12 +175,26 @@ class MemoService(
 
    private fun resolveTags(userId: Long, tagNames: List<String>): Set<MemoTagRef> {
         return tagNames.distinct().map { name ->
+            validateTagName(name)
+
             val tag = tagRepository.findByUserIdAndName(userId, name)
                 .orElseGet {
                     tagRepository.save(Tag(userId = userId, name = name))
                 }
             MemoTagRef(tagId = tag.id!!)
         }.toSet()
+    }
+
+    private fun validateMemoContent(content: String?) {
+        if (content.isNullOrBlank()) {
+            throw DomainException(ErrorCode.MEMO_CONTENT_CANNOT_BE_BLANK)
+        }
+    }
+
+    private fun validateTagName(name: String) {
+        if (name.isBlank()) {
+            throw DomainException(ErrorCode.TAG_NAME_CANNOT_BE_BLANK)
+        }
     }
 
     private fun mapToMemoResponse(memo: Memo, eventTitle: String): MemoResponse {

--- a/hangsha/src/main/kotlin/com/team1/hangsha/tag/service/TagService.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/tag/service/TagService.kt
@@ -21,6 +21,8 @@ class TagService(
 
     @Transactional
     fun createTag(userId: Long, req: CreateTagRequest): CreateTagResponse {
+        validateTagName(req.name)
+
         // 해당 유저에게 이미 같은 이름의 태그가 있는지 확인
         if (tagRepository.findByUserIdAndName(userId, req.name).isPresent) {
             throw DomainException(ErrorCode.TAG_ALREADY_EXISTS)
@@ -33,6 +35,8 @@ class TagService(
     // 태그 이름 변경 (전역 변경)
     @Transactional
     fun updateTag(userId: Long, tagId: Long, req: UpdateTagRequest): UpdateTagResponse {
+        validateTagName(req.name)
+
         val tag = tagRepository.findById(tagId)
             .orElseThrow { DomainException(ErrorCode.TAG_NOT_FOUND) }
 
@@ -60,5 +64,11 @@ class TagService(
         }
 
         tagRepository.delete(tag)
+    }
+
+    private fun validateTagName(name: String) {
+        if (name.isBlank()) {
+            throw DomainException(ErrorCode.TAG_NAME_CANNOT_BE_BLANK)
+        }
     }
 }

--- a/hangsha/src/test/kotlin/com/team1/hangsha/MemoTagIntegrationTest.kt
+++ b/hangsha/src/test/kotlin/com/team1/hangsha/MemoTagIntegrationTest.kt
@@ -200,6 +200,23 @@ class MemoTagIntegrationTest : IntegrationTestBase() {
     }
 
     @Test
+    fun `POST memos content가 빈 문자열이면 400이고 저장되지 않는다`() {
+        val (_, token) = dataGenerator.generateUserWithAccessToken()
+        val eventId = requireNotNull(dataGenerator.generateEvent(title = "EV").id)
+
+        mockMvc.perform(
+            post("/api/v1/memos")
+                .header("Authorization", bearer(token))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(createBody(eventId, ""))
+        )
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.code").value("MEMO_CONTENT_CANNOT_BE_BLANK"))
+
+        assertTrue(memoRepository.findAll().none())
+    }
+
+    @Test
     fun `POST memos 메모 생성 없는 이벤트면 404`() {
         val (_, token) = dataGenerator.generateUserWithAccessToken()
 
@@ -522,7 +539,7 @@ class MemoTagIntegrationTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `PATCH memos 메모 수정 content가 null이면 내용이 비워진다`() {
+    fun `PATCH memos 메모 수정 content가 null이면 400이고 DB는 변하지 않는다`() {
         val (_, token) = dataGenerator.generateUserWithAccessToken()
 
         val eventId = requireNotNull(dataGenerator.generateEvent(title = "EV").id)
@@ -544,11 +561,40 @@ class MemoTagIntegrationTest : IntegrationTestBase() {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(patchBody)
         )
-            .andExpect(status().isOk)
-            .andExpect(jsonPath("$.content").value(""))
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.code").value("MEMO_CONTENT_CANNOT_BE_BLANK"))
 
         val saved = memoRepository.findById(memoId).orElseThrow()
-        assertEquals("", saved.content)
+        assertEquals("will-clear", saved.content)
+    }
+
+    @Test
+    fun `PATCH memos 메모 수정 content가 빈 문자열이면 400이고 DB는 변하지 않는다`() {
+        val (_, token) = dataGenerator.generateUserWithAccessToken()
+
+        val eventId = requireNotNull(dataGenerator.generateEvent(title = "EV").id)
+
+        val created = mockMvc.perform(
+            post("/api/v1/memos")
+                .header("Authorization", bearer(token))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(createBody(eventId, "old", listOf("t1")))
+        ).andExpect(status().isOk).andReturn()
+
+        val memoId = objectMapper.readTree(created.response.contentAsString)["id"].asLong()
+
+        mockMvc.perform(
+            patch("/api/v1/memos/$memoId")
+                .header("Authorization", bearer(token))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(toJson(mapOf("content" to "")))
+        )
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.code").value("MEMO_CONTENT_CANNOT_BE_BLANK"))
+
+        val saved = memoRepository.findById(memoId).orElseThrow()
+        assertEquals("old", saved.content)
+        assertEquals(1, saved.tags.size)
     }
 
     @Test

--- a/hangsha/src/test/kotlin/com/team1/hangsha/TagIntegrationTest.kt
+++ b/hangsha/src/test/kotlin/com/team1/hangsha/TagIntegrationTest.kt
@@ -137,6 +137,23 @@ class TagIntegrationTest : IntegrationTestBase() {
             .andExpect(status().isUnauthorized)
     }
 
+    @Test
+    fun `태그 생성 이름이 빈 문자열이면 400이고 저장되지 않는다`() {
+        val (user, token) = dataGenerator.generateUserWithAccessToken()
+        val userId = requireNotNull(user.id)
+
+        mockMvc.perform(
+            post("/api/v1/tags")
+                .header("Authorization", bearer(token))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(createBody(""))
+        )
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.code").value("TAG_NAME_CANNOT_BE_BLANK"))
+
+        assertTrue(tagRepository.findAllByUserId(userId).isEmpty())
+    }
+
     // =========================================================
     // 태그 수정
     // =========================================================
@@ -211,6 +228,27 @@ class TagIntegrationTest : IntegrationTestBase() {
                 .content(createBody("t2"))
         )
             .andExpect(status().isConflict)
+    }
+
+    @Test
+    fun `태그 수정 이름이 빈 문자열이면 400이고 DB는 변하지 않는다`() {
+        val (user, token) = dataGenerator.generateUserWithAccessToken()
+        val userId = requireNotNull(user.id)
+
+        val tag = dataGenerator.generateTag(userId = userId, name = "old")
+        val tagId = requireNotNull(tag.id)
+
+        mockMvc.perform(
+            patch("/api/v1/tags/$tagId")
+                .header("Authorization", bearer(token))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(createBody(""))
+        )
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.code").value("TAG_NAME_CANNOT_BE_BLANK"))
+
+        val saved = tagRepository.findById(tagId).orElseThrow()
+        assertEquals("old", saved.name)
     }
 
     @Test


### PR DESCRIPTION
슬랙에서 얘기한 대로, 메모, 태그 >>요청에서 온 content 필드가 빈 문자열이면 거부 응답