### PR TITLE
feat: AI parser setting

### DIFF
--- a/hangsha/batch/src/main/kotlin/com/team1/hangsha/batch/BatchApplication.kt
+++ b/hangsha/batch/src/main/kotlin/com/team1/hangsha/batch/BatchApplication.kt
@@ -4,8 +4,6 @@ import com.team1.hangsha.com.team1.hangsha.config.JacksonConfig
 import com.team1.hangsha.common.upload.OciUploadService
 import com.team1.hangsha.config.OciConfig
 import com.team1.hangsha.config.TestValueLogger
-import com.team1.hangsha.event.service.EventSyncService
-import com.team1.hangsha.search.outbox.EventSearchOutboxWriter
 import org.springframework.boot.WebApplicationType
 import org.springframework.boot.autoconfigure.data.jdbc.JdbcRepositoriesAutoConfiguration
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
@@ -18,8 +16,6 @@ import org.springframework.context.annotation.Import
 @SpringBootApplication
 @Import(
     JacksonConfig::class,
-    EventSyncService::class,
-    EventSearchOutboxWriter::class,
     TestValueLogger::class,
     OciConfig::class,
     OciUploadService::class,

--- a/hangsha/batch/src/main/kotlin/com/team1/hangsha/batch/ai/EliceEventParserClient.kt
+++ b/hangsha/batch/src/main/kotlin/com/team1/hangsha/batch/ai/EliceEventParserClient.kt
@@ -1,0 +1,364 @@
+package com.team1.hangsha.batch.ai
+
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.team1.hangsha.event.dto.core.CrawledDetailSession
+import com.team1.hangsha.event.dto.core.CrawledProgramEvent
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.jsoup.Jsoup
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.util.concurrent.TimeUnit
+
+@Component
+class EliceEventParserClient(
+    private val objectMapper: ObjectMapper,
+    @Value("\${elice.ml-api.event-parser.enabled:false}")
+    private val enabled: Boolean,
+    @Value("\${elice.ml-api.event-parser.url:}")
+    private val url: String,
+    @Value("\${elice.ml-api.event-parser.model:}")
+    private val model: String,
+    @Value("\${elice.ml-api.event-parser.api-key:}")
+    private val apiKey: String,
+) {
+    private val client = OkHttpClient.Builder()
+        .connectTimeout(10, TimeUnit.SECONDS)
+        .readTimeout(60, TimeUnit.SECONDS)
+        .callTimeout(90, TimeUnit.SECONDS)
+        .build()
+
+    fun enrich(events: List<CrawledProgramEvent>, batchSize: Int = 1): List<CrawledProgramEvent> {
+        if (!isConfigured()) return events
+        if (events.isEmpty()) return events
+
+        return events.chunked(batchSize.coerceAtLeast(1)).flatMapIndexed { chunkIndex, chunk ->
+            val parsedById = runCatching { parseChunk(chunk) }
+                .onFailure { e ->
+                    println("[AI_PARSER] chunk=$chunkIndex failed: ${e::class.simpleName} ${e.message}")
+                }
+                .getOrDefault(emptyMap())
+
+            chunk.map { event ->
+                val key = event.parserKey()
+                val parsed = parsedById[key]
+                if (parsed == null) {
+                    println("[AI_PARSER] no parsed result for key=$key title=${event.title}")
+                    event
+                } else {
+                    event.merge(parsed)
+                }
+            }
+        }
+    }
+
+    private fun isConfigured(): Boolean =
+        enabled && url.isNotBlank() && model.isNotBlank() && apiKey.isNotBlank()
+
+    private fun parseChunk(events: List<CrawledProgramEvent>): Map<String, ParsedEvent> {
+        val payload = buildPayload(events)
+        val requestBody = objectMapper.writeValueAsString(payload).toRequestBody(JSON)
+        val request = Request.Builder()
+            .url(chatCompletionsUrl())
+            .post(requestBody)
+            .header("Content-Type", "application/json")
+            .header("Authorization", "Bearer $apiKey")
+            .build()
+
+        client.newCall(request).execute().use { response ->
+            val responseText = response.body?.string().orEmpty()
+            if (!response.isSuccessful) {
+                throw IllegalStateException("Elice ML API failed. code=${response.code} body=${responseText.take(500)}")
+            }
+
+            return parseResponseText(responseText)
+                .associateBy { it.id }
+        }
+    }
+
+    private fun buildPayload(events: List<CrawledProgramEvent>): Map<String, Any?> =
+        mapOf(
+            "model" to model,
+            "messages" to listOf(
+                mapOf(
+                    "role" to "system",
+                    "content" to SYSTEM_PROMPT,
+                ),
+                mapOf(
+                    "role" to "user",
+                    "content" to objectMapper.writeValueAsString(
+                        mapOf(
+                            "currentDate" to LocalDate.now(SEOUL).toString(),
+                            "events" to events.map { it.toPromptEvent() },
+                        )
+                    ),
+                ),
+            ),
+            "max_completion_tokens" to 4096,
+            "stream" to false,
+            "response_format" to mapOf("type" to "json_object"),
+        )
+
+    private fun chatCompletionsUrl(): String {
+        val trimmed = url.trim().trimEnd('/')
+        return if (trimmed.endsWith("/v1/chat/completions")) {
+            trimmed
+        } else {
+            "$trimmed/v1/chat/completions"
+        }
+    }
+
+    private fun parseResponseText(text: String): List<ParsedEvent> {
+        val content = extractModelContent(text)
+        val json = extractJson(content)
+        val root = objectMapper.readTree(json)
+        val itemsNode = when {
+            root.isArray -> root
+            root.has("items") -> root.get("items")
+            root.has("events") -> root.get("events")
+            root.has("id") -> return listOf(objectMapper.convertValue(root, ParsedEvent::class.java))
+            else -> throw IllegalArgumentException("AI response JSON must be an array or contain items/events")
+        }
+
+        return objectMapper.convertValue(itemsNode, object : TypeReference<List<ParsedEvent>>() {})
+    }
+
+    private fun extractModelContent(text: String): String {
+        val trimmed = text.trim()
+        return runCatching {
+            val root = objectMapper.readTree(trimmed)
+            findFirstText(root, "content")
+                ?: findFirstText(root, "text")
+                ?: findFirstText(root, "output_text")
+                ?: trimmed
+        }.getOrDefault(trimmed)
+    }
+
+    private fun findFirstText(node: JsonNode, fieldName: String): String? {
+        if (node.isObject && node.has(fieldName) && node.get(fieldName).isTextual) {
+            return node.get(fieldName).asText()
+        }
+        if (node.isObject || node.isArray) {
+            val iterator = node.elements()
+            while (iterator.hasNext()) {
+                findFirstText(iterator.next(), fieldName)?.let { return it }
+            }
+        }
+        return null
+    }
+
+    private fun extractJson(text: String): String {
+        val withoutFence = text.trim()
+            .removePrefix("```json")
+            .removePrefix("```")
+            .removeSuffix("```")
+            .trim()
+
+        val arrayStart = withoutFence.indexOf('[')
+        val objectStart = withoutFence.indexOf('{')
+        val start = listOf(arrayStart, objectStart)
+            .filter { it >= 0 }
+            .minOrNull()
+            ?: throw IllegalArgumentException("AI response does not contain JSON")
+
+        val endChar = if (withoutFence[start] == '[') ']' else '}'
+        val end = withoutFence.lastIndexOf(endChar)
+        if (end < start) throw IllegalArgumentException("AI response JSON is incomplete")
+
+        return withoutFence.substring(start, end + 1)
+    }
+
+    companion object {
+        private val JSON = "application/json; charset=utf-8".toMediaType()
+        private val SEOUL = ZoneId.of("Asia/Seoul")
+
+        private const val SYSTEM_PROMPT = """
+You are a semantic parser for Seoul National University event data.
+Return JSON only. Do not use markdown.
+
+For each input event, return exactly one item with this schema:
+{
+  "id": "same id from input",
+  "organization": string or null,
+  "category": one of ["교육(특강/세미나)", "공모전/경진대회", "현장학습/인턴", "사회공헌(봉사)", "학습/진로상담", "OpenLnL", "기타"],
+  "applyStart": "yyyy-MM-ddTHH:mm:ss" or null,
+  "applyEnd": "yyyy-MM-ddTHH:mm:ss" or null,
+  "eventStart": "yyyy-MM-ddTHH:mm:ss" or null,
+  "eventEnd": "yyyy-MM-ddTHH:mm:ss" or null,
+  "warnings": string[]
+}
+
+Do not return status. The backend will infer recruitment status.
+Use currentDate's year when a date omits the year.
+If a date range crosses December to January, use the next year for January.
+
+Period policy:
+1. If listPeriodText is a single date, it is usually the event period.
+2. If listPeriodText is a range and mainContentText contains "모집" or "신청", treat it as apply period.
+3. If listPeriodText is a range and mainContentText does not contain "모집" or "신청", treat it as event period.
+4. If the event period is needed, refine it from lines containing "시간", "기간", or "일시".
+5. If the list range is treated as apply period, event period may be null.
+"""
+    }
+}
+
+private data class PromptEvent(
+    val id: String,
+    val title: String?,
+    val majorTypes: List<String>,
+    val listPeriodText: String?,
+    val mainContentText: String?,
+)
+
+data class ParsedEvent(
+    val id: String,
+    val organization: String? = null,
+    val category: String? = null,
+    val applyStart: String? = null,
+    val applyEnd: String? = null,
+    val eventStart: String? = null,
+    val eventEnd: String? = null,
+    val warnings: List<String> = emptyList(),
+)
+
+private fun CrawledProgramEvent.toPromptEvent(): PromptEvent =
+    PromptEvent(
+        id = parserKey(),
+        title = title,
+        majorTypes = majorTypes,
+        listPeriodText = listOfNotNull(
+            buildRangeText(applyStart, applyEnd),
+            buildRangeText(activityStart, activityEnd),
+        ).joinToString(" / ").takeIf { it.isNotBlank() },
+        mainContentText = mainContentHtml?.toPlainText()?.take(MAX_CONTENT_CHARS),
+    )
+
+private fun CrawledProgramEvent.merge(parsed: ParsedEvent): CrawledProgramEvent {
+    val organization = parsed.organization?.clean()
+    val category = parsed.category?.clean()?.takeIf { it in PROGRAM_TYPES }
+    val mergedMajorTypes = mergeMajorTypes(majorTypes, organization, category)
+
+    val applyEndDate = parsed.applyEnd.toLocalDateString() ?: applyEnd
+    val applyStartDate = parsed.applyStart.toLocalDateString()
+        ?: applyStart
+        ?: applyEndDate?.let { LocalDate.now(ZoneId.of("Asia/Seoul")).toString() }
+    val eventStartDateTime = parsed.eventStart.toLocalDateTimeOrNull()
+    val eventEndDateTime = parsed.eventEnd.toLocalDateTimeOrNull()
+    val eventStartDate = eventStartDateTime?.toLocalDate()?.toString() ?: activityStart
+    val eventEndDate = eventEndDateTime?.toLocalDate()?.toString() ?: activityEnd
+    val aiDetailSession = buildDetailSession(eventStartDateTime, eventEndDateTime)
+
+    return copy(
+        majorTypes = mergedMajorTypes,
+        applyStart = applyStartDate,
+        applyEnd = applyEndDate,
+        activityStart = eventStartDate,
+        activityEnd = eventEndDate,
+        status = inferStatus(applyStartDate, applyEndDate, eventStartDate, eventEndDate) ?: status,
+        detailSessions = aiDetailSession?.let { listOf(it) } ?: detailSessions,
+        isPeriodEvent = if (aiDetailSession != null) false else isPeriodEvent,
+    )
+}
+
+private fun mergeMajorTypes(existing: List<String>, organization: String?, category: String?): List<String> {
+    val org = organization ?: existing.getOrNull(0)
+    val type = category ?: existing.getOrNull(1)
+    return listOfNotNull(org, type).filter { it.isNotBlank() }
+}
+
+private fun buildDetailSession(start: LocalDateTime?, end: LocalDateTime?): CrawledDetailSession? {
+    if (start == null && end == null) return null
+    val safeStart = start ?: end ?: return null
+    val safeEnd = end ?: safeStart
+    val hasTime = safeStart.toLocalTime() != LocalTime.MIN || safeEnd.toLocalTime() != LocalTime.of(23, 59, 59)
+    if (!hasTime && safeStart.toLocalDate() != safeEnd.toLocalDate()) return null
+
+    return CrawledDetailSession(
+        round = 1,
+        startDate = safeStart.toLocalDate().toString(),
+        endDate = safeEnd.toLocalDate().toString(),
+        startTime = safeStart.toLocalTime().format(HH_MM),
+        endTime = safeEnd.toLocalTime().format(HH_MM),
+    )
+}
+
+private fun inferStatus(
+    applyStart: String?,
+    applyEnd: String?,
+    eventStart: String?,
+    eventEnd: String?,
+): String? {
+    val today = LocalDate.now(ZoneId.of("Asia/Seoul"))
+    val applyStartDate = applyStart.toLocalDateOrNull()
+    val applyEndDate = applyEnd.toLocalDateOrNull()
+
+    if (applyStartDate != null && applyEndDate != null) {
+        return when {
+            applyStartDate.isAfter(today) -> "모집대기"
+            !applyEndDate.isBefore(today) -> "모집중"
+            else -> "모집마감"
+        }
+    }
+
+    val eventEndDate = eventEnd.toLocalDateOrNull() ?: eventStart.toLocalDateOrNull()
+    return eventEndDate?.let {
+        if (!it.isBefore(today)) "모집중" else "모집마감"
+    }
+}
+
+private fun String?.toPlainText(): String =
+    this?.let { Jsoup.parse(it).text().replace(Regex("\\s+"), " ").trim() }.orEmpty()
+
+private fun String?.clean(): String? =
+    this?.trim()?.takeIf { it.isNotBlank() }
+
+private fun String?.toLocalDateString(): String? =
+    toLocalDateTimeOrNull()?.toLocalDate()?.toString() ?: toLocalDateOrNull()?.toString()
+
+private fun String?.toLocalDateTimeOrNull(): LocalDateTime? {
+    val value = clean() ?: return null
+    return runCatching { LocalDateTime.parse(value) }
+        .recoverCatching { LocalDate.parse(value).atStartOfDay() }
+        .getOrNull()
+}
+
+private fun String?.toLocalDateOrNull(): LocalDate? {
+    val value = clean() ?: return null
+    return runCatching { LocalDate.parse(value.take(10)) }.getOrNull()
+}
+
+private fun buildRangeText(start: String?, end: String?): String? {
+    val s = start.clean()
+    val e = end.clean()
+    return when {
+        s != null && e != null && s != e -> "$s ~ $e"
+        s != null -> s
+        e != null -> e
+        else -> null
+    }
+}
+
+private fun CrawledProgramEvent.parserKey(): String =
+    dataSeq?.takeIf { it.isNotBlank() } ?: applyLink?.takeIf { it.isNotBlank() } ?: title.orEmpty()
+
+private val PROGRAM_TYPES = setOf(
+    "교육(특강/세미나)",
+    "공모전/경진대회",
+    "현장학습/인턴",
+    "사회공헌(봉사)",
+    "학습/진로상담",
+    "OpenLnL",
+    "기타",
+)
+
+private val HH_MM: DateTimeFormatter = DateTimeFormatter.ofPattern("HH:mm")
+private const val MAX_CONTENT_CHARS = 6000

--- a/hangsha/batch/src/main/kotlin/com/team1/hangsha/batch/crawler/SnuCalendarCrawler.kt
+++ b/hangsha/batch/src/main/kotlin/com/team1/hangsha/batch/crawler/SnuCalendarCrawler.kt
@@ -160,7 +160,7 @@ class SnuCalendarCrawler(
         return CrawledProgramEvent(
             dataSeq = listItem.bbsidx,
             applyLink = sourceUrl,
-            majorTypes = listOf("SNU 캘린더"),
+            majorTypes = emptyList(),
             title = title,
             status = "상태 미제공",
             operationMode = null,
@@ -221,7 +221,7 @@ class SnuCalendarCrawler(
         return CrawledProgramEvent(
             dataSeq = bbsidx,
             applyLink = sourceUrl,
-            majorTypes = listOf("SNU 캘린더"),
+            majorTypes = emptyList(),
             title = title,
             status = "상태 미제공",
             activityStart = period.start,

--- a/hangsha/batch/src/main/kotlin/com/team1/hangsha/batch/crawler/SnuCalendarCrawler.kt
+++ b/hangsha/batch/src/main/kotlin/com/team1/hangsha/batch/crawler/SnuCalendarCrawler.kt
@@ -113,7 +113,7 @@ class SnuCalendarCrawler(
         val content = doc.selectFirst(".board-view .content") ?: doc.selectFirst(".view .content")
         val contentHtml = content?.html()?.trim()?.takeIf { it.isNotBlank() }
         val contentText = content?.text()?.normalize().orEmpty()
-        if (contentText.contains("비교과")) {
+        if (contentText.contains("비교과") || contentHtml.orEmpty().contains("extra.snu.ac.kr", ignoreCase = true)) {
             if (debug) println("[SNU-CALENDAR] skip duplicate extra-snu candidate url=$sourceUrl")
             return null
         }

--- a/hangsha/batch/src/main/kotlin/com/team1/hangsha/batch/job/ExtraSnuSyncRunner.kt
+++ b/hangsha/batch/src/main/kotlin/com/team1/hangsha/batch/job/ExtraSnuSyncRunner.kt
@@ -1,6 +1,7 @@
 package com.team1.hangsha.batch.job
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.team1.hangsha.batch.ai.EliceEventParserClient
 import com.team1.hangsha.batch.crawler.DetailSession
 import com.team1.hangsha.batch.crawler.ExtraSnuCrawler
 import com.team1.hangsha.batch.crawler.ProgramEvent
@@ -12,10 +13,14 @@ import com.team1.hangsha.config.TestValueLogger
 import com.team1.hangsha.event.dto.core.CrawledDetailSession
 import com.team1.hangsha.event.dto.core.CrawledProgramEvent
 import com.team1.hangsha.event.model.EventPeriodPolicy
+import com.team1.hangsha.event.repository.EventRepository
 import com.team1.hangsha.event.service.EventSyncService
+import com.team1.hangsha.search.outbox.EventSearchOutboxWriter
 import org.springframework.boot.ApplicationArguments
 import org.springframework.boot.ApplicationRunner
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.beans.factory.ObjectProvider
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Import
 import org.springframework.stereotype.Component
@@ -27,8 +32,10 @@ import kotlin.system.exitProcess
 @Component
 @ConditionalOnProperty(name = ["job"], havingValue = "extra-snu-sync", matchIfMissing = true)
 class ExtraSnuSyncRunner(
-    private val eventSyncService: EventSyncService,
+    private val eventSyncServiceProvider: ObjectProvider<EventSyncService>,
+    private val eventRepositoryProvider: ObjectProvider<EventRepository>,
     private val ociUploadService: OciUploadService,
+    private val eliceEventParserClient: EliceEventParserClient,
     private val objectMapper: ObjectMapper,
 ) : ApplicationRunner {
 
@@ -87,7 +94,7 @@ class ExtraSnuSyncRunner(
                     continue
                 }
 
-                val result = eventSyncService.sync(crawledEvents)
+                val result = eventSyncService().sync(crawledEvents)
                 totalUpserted += result.upserted
                 totalSkipped += result.skipped
 
@@ -106,15 +113,21 @@ class ExtraSnuSyncRunner(
                 )
             )
 
-            if (opt.outFile != null) {
-                dumpBuffer += snuCalendarEvents
+            val parsedSnuCalendarEvents = if (opt.aiParser) {
+                enrichNewSnunowEvents(snuCalendarEvents, opt.aiParserBatchSize)
+            } else {
+                snuCalendarEvents
             }
 
-            totalCrawled += snuCalendarEvents.size
+            if (opt.outFile != null) {
+                dumpBuffer += parsedSnuCalendarEvents
+            }
+
+            totalCrawled += parsedSnuCalendarEvents.size
             if (opt.dumpOnly) {
-                println("SNU calendar crawled: total=${snuCalendarEvents.size}")
+                println("SNU calendar crawled: total=${parsedSnuCalendarEvents.size}")
             } else {
-                val result = eventSyncService.sync(snuCalendarEvents)
+                val result = eventSyncService().sync(parsedSnuCalendarEvents)
                 totalUpserted += result.upserted
                 totalSkipped += result.skipped
 
@@ -133,7 +146,7 @@ class ExtraSnuSyncRunner(
         if (opt.dumpOnly) {
             println("Crawled $totalCrawled rows (dump-only mode)")
         } else {
-            val closedExpired = eventSyncService.closeExpiredRecruitingEvents() // 행사 마감 처리
+            val closedExpired = eventSyncService().closeExpiredRecruitingEvents() // 행사 마감 처리
 
             println(
                 "Synced $totalUpserted rows from $totalCrawled crawled events " +
@@ -148,6 +161,34 @@ class ExtraSnuSyncRunner(
         path.parent?.let { Files.createDirectories(it) }
         objectMapper.writerWithDefaultPrettyPrinter().writeValue(path.toFile(), rows)
     }
+
+    private fun eventSyncService(): EventSyncService =
+        eventSyncServiceProvider.getIfAvailable()
+            ?: throw IllegalStateException("EventSyncService is unavailable. Remove --dumpOnly only when DB settings are configured.")
+
+    private fun enrichNewSnunowEvents(
+        events: List<CrawledProgramEvent>,
+        batchSize: Int,
+    ): List<CrawledProgramEvent> {
+        val repository = eventRepositoryProvider.getIfAvailable()
+        val parserTargets = events.filter { event ->
+            val applyLink = event.applyLink?.trim().orEmpty()
+            if (!applyLink.isSnunowEventLink()) {
+                false
+            } else if (repository == null) {
+                true
+            } else {
+                !repository.existsByApplyLink(applyLink)
+            }
+        }
+
+        if (parserTargets.isEmpty()) return events
+
+        val parsedByKey = eliceEventParserClient.enrich(parserTargets, batchSize)
+            .associateBy { it.parserKey() }
+
+        return events.map { parsedByKey[it.parserKey()] ?: it }
+    }
 }
 
 private data class BatchArgs(
@@ -161,6 +202,8 @@ private data class BatchArgs(
     val withSnuCalendar: Boolean = true,
     val snuCalendarStartPage: Int = 1,
     val snuCalendarMaxPages: Int = 4,
+    val aiParser: Boolean = false,
+    val aiParserBatchSize: Int = 1,
 ) {
     companion object {
         fun from(args: ApplicationArguments): BatchArgs {
@@ -183,6 +226,8 @@ private data class BatchArgs(
                 withSnuCalendar = !args.containsOption("noSnuCalendar"),
                 snuCalendarStartPage = single("snuCalendarStartPage")?.toInt() ?: 1,
                 snuCalendarMaxPages = single("snuCalendarMaxPages")?.toInt() ?: 4,
+                aiParser = args.containsOption("aiParser"),
+                aiParserBatchSize = single("aiParserBatchSize")?.toInt()?.coerceAtLeast(1) ?: 1,
             )
         }
     }
@@ -208,13 +253,20 @@ private fun ProgramEvent.isPeriodEventFromList(): Boolean {
 @Configuration
 @ConditionalOnProperty(name = ["job"], havingValue = "extra-snu-sync", matchIfMissing = true)
 @Import(
-    DatabaseConfig::class,
-    EventSyncService::class,
     TestValueLogger::class,
     OciConfig::class,
     OciUploadService::class,
 )
 class ExtraSnuSyncConfiguration
+
+@Configuration
+@ConditionalOnExpression("'\${job:extra-snu-sync}' == 'extra-snu-sync' && '\${dumpOnly:false}' == 'false'")
+@Import(
+    DatabaseConfig::class,
+    EventSyncService::class,
+    EventSearchOutboxWriter::class,
+)
+class ExtraSnuSyncDatabaseConfiguration
 
 private fun ProgramEvent.toCrawledProgramEvent(): CrawledProgramEvent {
     val isPeriodEvent = isPeriodEventFromList()
@@ -253,3 +305,9 @@ private fun DetailSession.toCrawledDetailSession(): CrawledDetailSession =
         startTime = startTime,
         endTime = endTime
     )
+
+private fun String.isSnunowEventLink(): Boolean =
+    startsWith("https://www.snu.ac.kr/snunow/events")
+
+private fun CrawledProgramEvent.parserKey(): String =
+    dataSeq?.takeIf { it.isNotBlank() } ?: applyLink?.takeIf { it.isNotBlank() } ?: title.orEmpty()

--- a/hangsha/common/src/main/kotlin/com/team1/hangsha/event/repository/EventRepository.kt
+++ b/hangsha/common/src/main/kotlin/com/team1/hangsha/event/repository/EventRepository.kt
@@ -33,17 +33,23 @@ interface EventRepository : CrudRepository<Event, Long> {
     UPDATE events
     SET status_id = :closedStatusId
     WHERE admin_deleted = false
-      AND status_id = :recruitingStatusId
-      AND apply_end IS NOT NULL
-      AND apply_end < :now
+      AND status_id = :statusId
+      AND (
+        (apply_end IS NOT NULL AND apply_end < :now)
+        OR (
+          apply_link LIKE 'https://www.snu.ac.kr/snunow/events%'
+          AND COALESCE(event_end, event_start) IS NOT NULL
+          AND COALESCE(event_end, event_start) < :now
+        )
+      )
       AND (
         admin_overridden_fields IS NULL
         OR JSON_CONTAINS(admin_overridden_fields, JSON_QUOTE('statusId')) = 0
       )
     """
     )
-    fun closeExpiredRecruitingEvents(
-        @Param("recruitingStatusId") recruitingStatusId: Long,
+    fun closeExpiredEventsByStatus(
+        @Param("statusId") statusId: Long,
         @Param("closedStatusId") closedStatusId: Long,
         @Param("now") now: LocalDateTime,
     ): Int

--- a/hangsha/common/src/main/kotlin/com/team1/hangsha/event/service/EventSyncService.kt
+++ b/hangsha/common/src/main/kotlin/com/team1/hangsha/event/service/EventSyncService.kt
@@ -63,12 +63,11 @@ class EventSyncService(
             val orgId = orgName?.let { getOrCreateCategoryId(orgGroupId, it) }
             val typeName = normalizeProgramType(e)
 
-            val statusName = normalizeStatus(e.status)
-            val statusId = statusName?.let { findCategoryId(statusGroupId, it) }
             val eventTypeId = typeName?.let { findCategoryId(typeGroupId, it) }
 
             val applyStart = e.applyStart?.let { dateStart(it) }
             val applyEnd = e.applyEnd?.let { dateEnd(it) }
+            val now = LocalDateTime.now(ZoneId.of("Asia/Seoul"))
 
             val sessions = if (e.isPeriodEvent == true) {
                 emptyList()
@@ -135,6 +134,15 @@ class EventSyncService(
                     eventStart = eventStart,
                     eventEnd = eventEnd,
                 )
+                val statusName = normalizeStatus(
+                    raw = e.status,
+                    event = e,
+                    applyEnd = applyEnd,
+                    eventStart = eventStart,
+                    eventEnd = eventEnd,
+                    now = now,
+                )
+                val statusId = statusName?.let { findCategoryId(statusGroupId, it) }
 
                 val crawledTagsJson = if (cleanedTags.isEmpty()) {
                     null
@@ -208,11 +216,22 @@ class EventSyncService(
 
         val now = LocalDateTime.now(ZoneId.of("Asia/Seoul"))
 
-        return eventRepository.closeExpiredRecruitingEvents(
-            recruitingStatusId = recruitingStatusId,
+        val unknownStatusId = findCategoryId(statusGroupId, "상태 미제공")
+
+        val closedRecruiting = eventRepository.closeExpiredEventsByStatus(
+            statusId = recruitingStatusId,
             closedStatusId = closedStatusId,
             now = now,
         )
+        val closedUnknown = unknownStatusId?.let {
+            eventRepository.closeExpiredEventsByStatus(
+                statusId = it,
+                closedStatusId = closedStatusId,
+                now = now,
+            )
+        } ?: 0
+
+        return closedRecruiting + closedUnknown
     }
 
     private fun requireGroupId(name: String): Long {
@@ -299,12 +318,42 @@ class EventSyncService(
         }
     }
 
-    private fun normalizeStatus(raw: String?): String? {
+    private fun normalizeStatus(
+        raw: String?,
+        event: CrawledProgramEvent,
+        applyEnd: LocalDateTime?,
+        eventStart: LocalDateTime?,
+        eventEnd: LocalDateTime?,
+        now: LocalDateTime,
+    ): String? {
         val s = raw?.trim()
         if (s.isNullOrBlank()) return null
         return when (s) {
             "마감임박" -> "모집중"
+            "상태 미제공" -> inferUnknownStatus(event, applyEnd, eventStart, eventEnd, now)
             else -> s
+        }
+    }
+
+    private fun inferUnknownStatus(
+        event: CrawledProgramEvent,
+        applyEnd: LocalDateTime?,
+        eventStart: LocalDateTime?,
+        eventEnd: LocalDateTime?,
+        now: LocalDateTime,
+    ): String {
+        val hasOpenApplyPeriod = applyEnd != null && !applyEnd.isBefore(now)
+        val eventNotExpired = (eventEnd ?: eventStart)?.let { !it.isBefore(now) } ?: false
+        val hasApplyOrSupportText = sequenceOf(
+            event.title,
+            event.mainContentHtml,
+            event.tags.joinToString(" "),
+        ).any { it?.contains(Regex("""신청|지원""")) == true }
+
+        return if (hasOpenApplyPeriod || hasApplyOrSupportText || eventNotExpired) {
+            "모집중"
+        } else {
+            "모집마감"
         }
     }
 

--- a/hangsha/src/main/resources/db/migration/V29__remove_unknown_recruitment_status.sql
+++ b/hangsha/src/main/resources/db/migration/V29__remove_unknown_recruitment_status.sql
@@ -1,0 +1,29 @@
+UPDATE events e
+    JOIN categories unknown_status ON unknown_status.id = e.status_id
+    JOIN category_groups status_group ON status_group.id = unknown_status.group_id
+    JOIN categories next_status ON next_status.group_id = status_group.id
+        AND next_status.name = CASE
+            WHEN e.apply_end >= NOW()
+                OR COALESCE(e.event_end, e.event_start) >= NOW()
+                OR COALESCE(e.title, '') REGEXP '신청|지원'
+                OR COALESCE(e.main_content_html, '') REGEXP '신청|지원'
+                OR COALESCE(e.tags, '') REGEXP '신청|지원'
+                THEN '모집중'
+            ELSE '모집마감'
+        END
+SET e.status_id = next_status.id
+WHERE status_group.name = '모집현황'
+  AND unknown_status.name = '상태 미제공';
+
+DELETE uic
+FROM user_interest_categories uic
+    JOIN categories unknown_status ON unknown_status.id = uic.category_id
+    JOIN category_groups status_group ON status_group.id = unknown_status.group_id
+WHERE status_group.name = '모집현황'
+  AND unknown_status.name = '상태 미제공';
+
+DELETE unknown_status
+FROM categories unknown_status
+    JOIN category_groups status_group ON status_group.id = unknown_status.group_id
+WHERE status_group.name = '모집현황'
+  AND unknown_status.name = '상태 미제공';

--- a/hangsha/src/main/resources/db/migration/V29__remove_unknown_recruitment_status.sql
+++ b/hangsha/src/main/resources/db/migration/V29__remove_unknown_recruitment_status.sql
@@ -1,17 +1,22 @@
-UPDATE events e
+INSERT INTO event_search_outbox (event_id, operation, status)
+SELECT e.id, 'DELETE', 'PENDING'
+FROM events e
     JOIN categories unknown_status ON unknown_status.id = e.status_id
     JOIN category_groups status_group ON status_group.id = unknown_status.group_id
-    JOIN categories next_status ON next_status.group_id = status_group.id
-        AND next_status.name = CASE
-            WHEN e.apply_end >= NOW()
-                OR COALESCE(e.event_end, e.event_start) >= NOW()
-                OR COALESCE(e.title, '') REGEXP '신청|지원'
-                OR COALESCE(e.main_content_html, '') REGEXP '신청|지원'
-                OR COALESCE(e.tags, '') REGEXP '신청|지원'
-                THEN '모집중'
-            ELSE '모집마감'
-        END
-SET e.status_id = next_status.id
+WHERE status_group.name = '모집현황'
+  AND unknown_status.name = '상태 미제공'
+  AND NOT EXISTS (
+      SELECT 1
+      FROM event_search_outbox eso
+      WHERE eso.event_id = e.id
+        AND eso.operation = 'DELETE'
+        AND eso.status = 'PENDING'
+  );
+
+DELETE e
+FROM events e
+    JOIN categories unknown_status ON unknown_status.id = e.status_id
+    JOIN category_groups status_group ON status_group.id = unknown_status.group_id
 WHERE status_group.name = '모집현황'
   AND unknown_status.name = '상태 미제공';
 

--- a/hangsha/src/main/resources/db/migration/V30__remove_snu_calendar_org_category.sql
+++ b/hangsha/src/main/resources/db/migration/V30__remove_snu_calendar_org_category.sql
@@ -1,0 +1,23 @@
+DELETE uic
+FROM user_interest_categories uic
+    JOIN categories c ON c.id = uic.category_id
+    JOIN category_groups cg ON cg.id = c.group_id
+WHERE cg.name = '주체기관'
+  AND c.name IN ('SNU 캘린더', 'SNU캘린더');
+
+UPDATE events e
+    JOIN categories snu_org ON snu_org.id = e.org_id
+    JOIN category_groups org_group ON org_group.id = snu_org.group_id
+SET e.org_id = NULL,
+    e.organization = CASE
+        WHEN e.organization IN ('SNU 캘린더', 'SNU캘린더') THEN NULL
+        ELSE e.organization
+    END
+WHERE org_group.name = '주체기관'
+  AND snu_org.name IN ('SNU 캘린더', 'SNU캘린더');
+
+DELETE c
+FROM categories c
+    JOIN category_groups cg ON cg.id = c.group_id
+WHERE cg.name = '주체기관'
+  AND c.name IN ('SNU 캘린더', 'SNU캘린더');


### PR DESCRIPTION
AI 파싱 대상: 주최 기관, 카테고리, 신청/행사 기간 (cf. 모집 상태 = rule-based)
majorTypes, apply/activity 시간

1. 크롤링할 때 mainContentHtml + 프롬프트로 GPT call 해서 페이로드에 쏘기 (나중에 최적화를 한다면: batch 단위로) 
2. response json 받아서 우리 DTO에 맞게 파싱
3. 파싱 결과를 그 event와 매칭해서 DB에 넣기 

>>

과연 dev db에서 잘 동작할 것인가.. 

