### PR TITLE
검색엔진에 대한 인덱싱 완료 시 row delete 하기

### DIFF
--- a/hangsha/src/main/kotlin/com/team1/hangsha/search/outbox/OutboxWorker.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/search/outbox/OutboxWorker.kt
@@ -32,7 +32,7 @@ class OutboxWorker(
                     EventSearchOutbox.Operation.DELETE ->
                         manticoreIndexService.deleteEvent(entry.eventId)
                 }
-                outboxRepository.updateStatus(entryId, "DONE", Instant.now())
+                outboxRepository.deleteById(entryId)
                 log.debug("outbox processed id={} eventId={} op={}", entryId, entry.eventId, entry.operation)
             } catch (e: Exception) {
                 outboxRepository.updateStatus(entryId, "FAILED", Instant.now())


### PR DESCRIPTION


기존에 쌓인 DONE 행 정리는 별도로 진행.

## #️⃣ 연관된 이슈

#141 

## 📝 작업 내용

- outbox 행이 처리 후에도 DONE 상태로 남아 테이블 rows가 계속 증가하는 문제를 수정. 
-> 색인 성공 시 행을 삭제하도록 함. 실패 행은 조사를 위해 FAILED로 그대로 남김. 

기존에 인서트 된 row들은 나중에 일괄 삭제할 예정

## ✅ 체크리스트
- [x] 로컬에서 정상 동작 확인
- [x] 기존 기능에 영향 없음
- [ ] 테스트 통과 (또는 테스트 없음)
- [ ] 브레이킹 체인지 여부 확인

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
