### PR TITLE
fix: sort by deadline

### DIFF
--- a/hangsha/src/main/kotlin/com/team1/hangsha/event/repository/EventQueryRepository.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/event/repository/EventQueryRepository.kt
@@ -243,13 +243,14 @@ class EventQueryRepository(
         return jdbc.query(sql, params) { rs, _ -> rs.toEvent() }
     }
 
+    /** 검색 전용 조회. 실제 정렬은 EventService.sortByDeadline() 에서 수행하고, 여기선 결정성만 확보한다. */
     fun findVisibleByIds(ids: List<Long>): List<Event> {
         if (ids.isEmpty()) return emptyList()
         val sql = """
             SELECT e.* FROM events e
             WHERE e.id IN (:ids)
               AND e.admin_deleted = false
-            ORDER BY COALESCE(e.event_start, e.apply_start) DESC, e.id DESC
+            ORDER BY e.id DESC
         """.trimIndent()
         return jdbc.query(sql, mapOf("ids" to ids)) { rs, _ -> rs.toEvent() }
     }

--- a/hangsha/src/main/kotlin/com/team1/hangsha/event/service/EventService.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/event/service/EventService.kt
@@ -221,7 +221,6 @@ class EventService(
 
         /**
          * TODO :
-         * 2. sorting
          * 3. categrory filtering
          */
 
@@ -229,7 +228,7 @@ class EventService(
         val safeSize = max(1, size)
         val offset = (safePage - 1) * safeSize
 
-        val allEvents = eventQueryRepository.findVisibleByIds(result.eventIds)
+        val allEvents = sortByDeadline(eventQueryRepository.findVisibleByIds(result.eventIds))
 
         // main_content_html 태그 제거 텍스트 캐시: 제외 필터와 하이라이트에서 재사용 (이벤트당 최대 1회 파싱)
         val contentTextCache = HashMap<Long, String?>()
@@ -288,6 +287,42 @@ class EventService(
 
         return SearchEventResponse(page = safePage, size = safeSize, total = filteredEvents.size, items = items)
     }
+
+    /**
+     * 검색 결과 정렬.
+     *
+     * 마감임박순(아직 안 지난 행사 오름차순) -> 이미 지난 행사(내림차순) -> 정렬 키가 없는 행사.
+     * "지났다"의 기준은 오늘 00:00 이므로, 오늘 날짜에 걸친 행사는 시각과 무관하게 상단에 남는다.
+     */
+    private fun sortByDeadline(events: List<Event>): List<Event> {
+        val cutoff = LocalDate.now().atStartOfDay()
+
+        val upcoming = mutableListOf<Pair<Event, LocalDateTime>>()
+        val past = mutableListOf<Pair<Event, LocalDateTime>>()
+        val undated = mutableListOf<Event>()
+
+        for (e in events) {
+            val key = searchSortKey(e)
+            when {
+                key == null -> undated += e
+                key.isBefore(cutoff) -> past += e to key
+                else -> upcoming += e to key
+            }
+        }
+
+        // 동점이면 id 내림차순(최신 등록 우선)으로 tie-break
+        return upcoming.sortedWith(
+            compareBy<Pair<Event, LocalDateTime>> { it.second }.thenByDescending { it.first.id }
+        ).map { it.first } +
+            past.sortedWith(
+                compareByDescending<Pair<Event, LocalDateTime>> { it.second }.thenByDescending { it.first.id }
+            ).map { it.first } +
+            undated.sortedByDescending { it.id }
+    }
+
+    /** 정렬 키: applyEnd > eventStart > applyStart > eventEnd (앞이 null이면 다음 것) */
+    private fun searchSortKey(e: Event): LocalDateTime? =
+        e.applyEnd ?: e.eventStart ?: e.applyStart ?: e.eventEnd
 
     private fun loadInterestMap(userId: Long?): Map<Long, Int> {
         if (userId == null) return emptyMap()

--- a/hangsha/src/test/kotlin/com/team1/hangsha/EventIntegrationTest.kt
+++ b/hangsha/src/test/kotlin/com/team1/hangsha/EventIntegrationTest.kt
@@ -253,31 +253,6 @@ class EventIntegrationTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `이벤트 제목 검색 query 가 공백이면 400`() {
-        mockMvc.perform(get("/api/v1/events/search/title?query=   "))
-            .andExpect(status().isBadRequest)
-    }
-
-    @Test
-    fun `이벤트 제목 검색 like 검색과 페이징이 동작한다`() {
-        dataGenerator.generateEvent(title = "Alpha 1")
-        dataGenerator.generateEvent(title = "Alpha 2")
-        dataGenerator.generateEvent(title = "Alpha 3")
-        dataGenerator.generateEvent(title = "Beta 1")
-
-        mockMvc.perform(get("/api/v1/events/search/title?query=Alpha&page=1&size=2"))
-            .andExpect(status().isOk)
-            .andExpect(jsonPath("$.page").value(1))
-            .andExpect(jsonPath("$.size").value(2))
-            .andExpect(jsonPath("$.total").value(3))
-            .andExpect(jsonPath("$.items.length()").value(2))
-
-        mockMvc.perform(get("/api/v1/events/search/title?query=Alpha&page=2&size=2"))
-            .andExpect(status().isOk)
-            .andExpect(jsonPath("$.items.length()").value(1))
-    }
-
-    @Test
     fun `이벤트 상세 조회 없는 이벤트면 404`() {
         mockMvc.perform(get("/api/v1/events/999999999"))
             .andExpect(status().isNotFound)
@@ -431,74 +406,6 @@ class EventIntegrationTest : IntegrationTestBase() {
     }
 
     // =========================================================
-    // Personalization excluded keyword
-    // =========================================================
-
-    @Test
-    fun `개인화 excluded keyword 가 있으면 로그인 상태에서 day search month 에서 제외된다`() {
-        val (_, token) = dataGenerator.generateUserWithAccessToken()
-        val date = LocalDate.now()
-        val dayStart = date.atStartOfDay()
-
-        mockMvc.perform(
-            post("/api/v1/users/me/excluded-keywords")
-                .header("Authorization", bearer(token))
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(toJson(mapOf("keyword" to "apple")))
-        ).andExpect(status().isCreated)
-
-        dataGenerator.generateEvent(
-            title = "apple conference",
-            eventStart = dayStart.plusHours(9),
-            eventEnd = dayStart.plusHours(10),
-        )
-        dataGenerator.generateEvent(
-            title = "banana conference",
-            eventStart = dayStart.plusHours(11),
-            eventEnd = dayStart.plusHours(12),
-        )
-
-        val dayRes = mockMvc.perform(
-            get("/api/v1/events/day?date=${ymd(date)}&page=1&size=20")
-                .header("Authorization", bearer(token))
-        )
-            .andExpect(status().isOk)
-            .andReturn()
-
-        val dayTitles = objectMapper.readTree(dayRes.response.contentAsString)["items"]
-            .map { it["title"].asText() }
-        require(dayTitles.contains("banana conference")) { "expected banana in day results" }
-        require(!dayTitles.contains("apple conference")) { "apple should be excluded in day results" }
-
-        val searchRes = mockMvc.perform(
-            get("/api/v1/events/search/title?query=conference&page=1&size=20")
-                .header("Authorization", bearer(token))
-        )
-            .andExpect(status().isOk)
-            .andReturn()
-
-        val searchTitles = objectMapper.readTree(searchRes.response.contentAsString)["items"]
-            .map { it["title"].asText() }
-        require(searchTitles.contains("banana conference")) { "expected banana in search results" }
-        require(!searchTitles.contains("apple conference")) { "apple should be excluded in search results" }
-
-        val from = date
-        val to = date.plusDays(2)
-        val monthRes = mockMvc.perform(
-            get(monthUrl(from, to))
-                .header("Authorization", bearer(token))
-        )
-            .andExpect(status().isOk)
-            .andReturn()
-
-        val byDate = objectMapper.readTree(monthRes.response.contentAsString)["byDate"]
-        byDate.fields().forEach { (_, bucket) ->
-            val titles = bucket["events"].mapNotNull { it["title"]?.asText() }
-            require(!titles.contains("apple conference")) { "apple should be excluded in month results" }
-        }
-    }
-
-    // =========================================================
     // Personalization interest category
     // =========================================================
 
@@ -608,39 +515,6 @@ class EventIntegrationTest : IntegrationTestBase() {
         require(first["matchedInterestPriority"].asInt() == 1) { "expected priority=1" }
     }
 
-    @Test
-    fun `개인화 search 에서 interest 우선정렬 되고 excluded keyword 도 같이 적용된다`() {
-        val (user, token) = dataGenerator.generateUserWithAccessToken()
-        val orgP1 = dataGenerator.generateOrgCategory(name = "ORG P1")
-        val orgP2 = dataGenerator.generateOrgCategory(name = "ORG P2")
-        dataGenerator.addUserInterestCategory(user, orgP1, priority = 1)
-        dataGenerator.addUserInterestCategory(user, orgP2, priority = 2)
-
-        mockMvc.perform(
-            post("/api/v1/users/me/excluded-keywords")
-                .header("Authorization", bearer(token))
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(toJson(mapOf("keyword" to "apple")))
-        ).andExpect(status().isCreated)
-
-        dataGenerator.generateEvent(title = "apple visible P1 hidden", orgId = orgP1.id!!)
-        dataGenerator.generateEvent(title = "visible P1", orgId = orgP1.id!!)
-        dataGenerator.generateEvent(title = "visible P2", orgId = orgP2.id!!)
-        dataGenerator.generateEvent(title = "visible NON")
-
-        val res = mockMvc.perform(
-            get("/api/v1/events/search/title?query=visible&page=1&size=20")
-                .header("Authorization", bearer(token))
-        )
-            .andExpect(status().isOk)
-            .andReturn()
-
-        val items = objectMapper.readTree(res.response.contentAsString)["items"]
-        val titles = items.map { it["title"].asText() }
-
-        require(!titles.contains("apple visible P1 hidden")) { "excluded keyword event leaked" }
-        assertEquals(listOf("visible P1", "visible P2", "visible NON"), titles)
-    }
 
     @Test
     fun `개인화 month 의 날짜 bucket 내부에서도 interest 우선정렬 되고 excluded keyword 는 숨긴다`() {


### PR DESCRIPTION
## 📝 작업 내용

- 검색 결과를 마감임박순 > 날짜 내림차순 으로 정렬합니다. 예를 들면 DDAY D-1 D-2 D-3 ... D+1 D+2 D+3 ... 정렬 키는 다음과 같이 정해집니다. applyEnd > eventStart > applyStart > eventEnd (앞이 null이면 다음 것)
- search 관련 불필요한 테스트들을 제거합니다.

## ✅ 체크리스트
- [x] 로컬에서 정상 동작 확인
- [ ] 기존 기능에 영향 없음
- [ ] 테스트 통과 (또는 테스트 없음)
- [ ] 브레이킹 체인지 여부 확인

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
