### PR TITLE
feat: add admin access code auth

### DIFF
--- a/hangsha/src/main/kotlin/com/team1/hangsha/admin/AdminAuthController.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/admin/AdminAuthController.kt
@@ -1,0 +1,25 @@
+package com.team1.hangsha.admin
+
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/admin/auth")
+class AdminAuthController(
+    private val adminAuthService: AdminAuthService,
+) {
+    @PostMapping("/session")
+    fun createSession(@RequestBody req: AdminSessionRequest): AdminSessionResponse {
+        return AdminSessionResponse(accessToken = adminAuthService.issueAccessToken(req.code))
+    }
+}
+
+data class AdminSessionRequest(
+    val code: String,
+)
+
+data class AdminSessionResponse(
+    val accessToken: String,
+)

--- a/hangsha/src/main/kotlin/com/team1/hangsha/admin/AdminAuthService.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/admin/AdminAuthService.kt
@@ -1,0 +1,37 @@
+package com.team1.hangsha.admin
+
+import com.team1.hangsha.common.error.DomainException
+import com.team1.hangsha.common.error.ErrorCode
+import com.team1.hangsha.user.JwtTokenProvider
+import org.springframework.core.env.Environment
+import org.springframework.stereotype.Service
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+
+@Service
+class AdminAuthService(
+    private val jwtTokenProvider: JwtTokenProvider,
+    private val environment: Environment,
+) {
+    fun issueAccessToken(code: String): String {
+        val expected = environment.getProperty("admin.access-code", "").trim()
+        val actual = code.trim()
+
+        if (expected.isBlank() || !constantTimeEquals(expected, actual)) {
+            throw DomainException(ErrorCode.AUTH_INVALID_CREDENTIALS, "관리자 접근 코드가 올바르지 않습니다")
+        }
+
+        return jwtTokenProvider.createAccessToken(ADMIN_SYSTEM_USER_ID, isAdmin = true)
+    }
+
+    private fun constantTimeEquals(expected: String, actual: String): Boolean {
+        val expectedBytes = expected.toByteArray(StandardCharsets.UTF_8)
+        val actualBytes = actual.toByteArray(StandardCharsets.UTF_8)
+
+        return MessageDigest.isEqual(expectedBytes, actualBytes)
+    }
+
+    companion object {
+        private const val ADMIN_SYSTEM_USER_ID = 0L
+    }
+}

--- a/hangsha/src/main/kotlin/com/team1/hangsha/config/SecurityConfig.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/config/SecurityConfig.kt
@@ -72,7 +72,7 @@ class SecurityConfig(
                         "/api/v1/categories/**",
                         // 테스트 페이지 / 로컬 편의
                         "/hangsha-search-test.html",
-                        "/api/v1/admin/search/reindex",
+                        "/api/v1/admin/auth/session",
                         // 파일 업로드
                         "/static/**",
                         "/api/v1/uploads/oci/**",


### PR DESCRIPTION
## 1. 어떤 기능을 구현했는지

- 어드민 페이지에서 일반 로그인 없이 access code로 admin 세션을 시작할 수 있는 API를 추가했습니다.
- `POST /api/v1/admin/auth/session`에서 access code를 검증한 뒤 기존 JWT 발급 로직으로 admin access token을 반환합니다.
- admin auth 세션 발급 API만 공개하고, 기존 admin API는 admin JWT가 있어야 접근되도록 유지했습니다.

## 2. 뭘 바꿨는지

- `AdminAuthController`, `AdminAuthService`를 추가했습니다.
- `admin.access-code` 설정값을 Spring Environment에서 읽어 검증하도록 했습니다.
- `SecurityConfig`에서 `/api/v1/admin/auth/session`만 `permitAll`로 열고, `/api/v1/admin/search/reindex`는 공개 경로에서 제외했습니다.
- 별도 admin 계정이나 별도 토큰 만료 설정을 만들지 않고 기존 `JwtTokenProvider`와 access token 만료 정책을 재사용했습니다.

## 3. 왜 그렇게 했는지

- 어드민 진입 UX는 단순화하되, 프론트엔드 단독 검증처럼 우회 가능한 구조는 피하기 위해 백엔드가 최종 권한 부여를 담당하도록 했습니다.
- 기존 admin JWT 기반 인가 흐름을 그대로 재사용하면 새 인증 모델을 크게 늘리지 않고도 현재 admin API 보호 방식과 자연스럽게 연결됩니다.
- access code는 OCI Vault를 통해 환경별로 주입되므로 코드에 비밀값을 넣지 않아도 됩니다.

## Checks

- `./gradlew :compileKotlin`
