### PR TITLE
이벤트 상세 정보를 내 메모 목록 엔드포인트 응답에 포함

### DIFF
--- a/hangsha/src/main/kotlin/com/team1/hangsha/memo/controller/MemoController.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/memo/controller/MemoController.kt
@@ -33,9 +33,20 @@ class MemoController(
     }
 
     @GetMapping
-    fun getMyMemos(@Parameter(hidden = true) @LoggedInUser user: User,): ResponseEntity<ListMemoResponse> {
+    @Operation(
+        summary = "List my memos",
+        description = """
+            내 메모 목록을 최신순으로 조회합니다.
+
+            각 메모에는 메모를 적은 행사 정보가 함께 내려갑니다.
+            - applyEnd: 지원 마감일 (D-Day 계산 기준). 행사가 없거나 마감일 미정이면 null
+            - organization: 주최기관 { id, name }. 주최기관 미분류면 null
+            - isBookmarked: 현재 사용자의 해당 행사 북마크 여부
+            """
+    )
+    fun getMyMemos(@Parameter(hidden = true) @LoggedInUser user: User,): ResponseEntity<ListMemoWithEventResponse> {
         val memos = memoService.getMyMemos(user.id!!)
-        return ResponseEntity.ok(ListMemoResponse(items = memos))
+        return ResponseEntity.ok(ListMemoWithEventResponse(items = memos))
     }
 
     @GetMapping("/by-event/{eventId}")

--- a/hangsha/src/main/kotlin/com/team1/hangsha/memo/dto/ListMemoResponse.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/memo/dto/ListMemoResponse.kt
@@ -1,7 +1,12 @@
 package com.team1.hangsha.memo.dto
 
 import com.team1.hangsha.memo.dto.core.MemoResponse
+import com.team1.hangsha.memo.dto.core.MemoWithEventResponse
 
 data class ListMemoResponse(
     val items: List<MemoResponse>
+)
+
+data class ListMemoWithEventResponse(
+    val items: List<MemoWithEventResponse>
 )

--- a/hangsha/src/main/kotlin/com/team1/hangsha/memo/dto/core/MemoDto.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/memo/dto/core/MemoDto.kt
@@ -1,8 +1,15 @@
 package com.team1.hangsha.memo.dto.core
 
 import java.time.Instant
+import java.time.LocalDateTime
 
 data class MemoTagResponse(
+    val id: Long,
+    val name: String
+)
+
+/** 메모가 달린 행사의 주최기관 (events.org_id -> categories) */
+data class MemoOrganizationResponse(
     val id: Long,
     val name: String
 )
@@ -15,4 +22,21 @@ data class MemoResponse(
     val tags: List<MemoTagResponse>,
     val createdAt: Instant?,
     val updatedAt: Instant?
+)
+
+/** 메모 목록 조회용. 메모에 달린 행사 정보를 함께 내려준다. */
+data class MemoWithEventResponse(
+    val id: Long,
+    val eventId: Long,
+    val eventTitle: String,
+    val content: String,
+    val tags: List<MemoTagResponse>,
+    val createdAt: Instant?,
+    val updatedAt: Instant?,
+
+    /** D-Day 계산 기준. 행사가 없거나 마감일 미정이면 null */
+    val applyEnd: LocalDateTime?,
+    /** 주최기관 미분류이면 null */
+    val organization: MemoOrganizationResponse?,
+    val isBookmarked: Boolean
 )

--- a/hangsha/src/main/kotlin/com/team1/hangsha/memo/repository/MemoQueryRepository.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/memo/repository/MemoQueryRepository.kt
@@ -1,0 +1,99 @@
+package com.team1.hangsha.memo.repository
+
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import org.springframework.stereotype.Repository
+import java.sql.ResultSet
+import java.time.Instant
+import java.time.LocalDateTime
+
+/** 메모 + 메모가 달린 행사 정보 한 줄 */
+data class MemoWithEventRow(
+    val id: Long,
+    val eventId: Long,
+    val content: String,
+    val createdAt: Instant?,
+    val updatedAt: Instant?,
+
+    val eventTitle: String?,
+    val applyEnd: LocalDateTime?,
+    val orgId: Long?,
+    val orgName: String?,
+    val isBookmarked: Boolean,
+)
+
+data class MemoTagRow(
+    val memoId: Long,
+    val tagId: Long,
+    val tagName: String,
+)
+
+@Repository
+class MemoQueryRepository(
+    private val jdbc: NamedParameterJdbcTemplate,
+) {
+    /**
+     * 유저의 메모를 행사 정보(마감일/주최기관/북마크 여부)와 함께 조회한다.
+     * events/categories/bookmarks는 LEFT JOIN이라 행사가 지워졌거나 주최기관 미분류여도 메모는 그대로 나온다.
+     */
+    fun findMemosWithEventByUserId(userId: Long): List<MemoWithEventRow> {
+        val sql = """
+            SELECT m.id             AS id,
+                   m.event_id       AS event_id,
+                   m.content        AS content,
+                   m.created_at     AS created_at,
+                   m.updated_at     AS updated_at,
+                   e.title          AS event_title,
+                   e.apply_end      AS apply_end,
+                   c.id             AS org_id,
+                   c.name           AS org_name,
+                   (b.id IS NOT NULL) AS is_bookmarked
+            FROM memos m
+            LEFT JOIN events e ON e.id = m.event_id
+            LEFT JOIN categories c ON c.id = e.org_id
+            LEFT JOIN bookmarks b ON b.event_id = m.event_id AND b.user_id = :userId
+            WHERE m.user_id = :userId
+            ORDER BY m.created_at DESC, m.id DESC
+        """.trimIndent()
+
+        return jdbc.query(sql, mapOf("userId" to userId)) { rs, _ -> rs.toMemoWithEventRow() }
+    }
+
+    fun findTagsByMemoIds(memoIds: List<Long>): List<MemoTagRow> {
+        if (memoIds.isEmpty()) return emptyList()
+
+        val sql = """
+            SELECT mt.memo_id AS memo_id,
+                   t.id       AS tag_id,
+                   t.name     AS tag_name
+            FROM memo_tags mt
+            JOIN tags t ON t.id = mt.tag_id
+            WHERE mt.memo_id IN (:memoIds)
+            ORDER BY mt.memo_id, t.id
+        """.trimIndent()
+
+        return jdbc.query(sql, mapOf("memoIds" to memoIds)) { rs, _ ->
+            MemoTagRow(
+                memoId = rs.getLong("memo_id"),
+                tagId = rs.getLong("tag_id"),
+                tagName = rs.getString("tag_name"),
+            )
+        }
+    }
+}
+
+private fun ResultSet.getLongOrNull(column: String): Long? =
+    getLong(column).let { if (wasNull()) null else it }
+
+private fun ResultSet.toMemoWithEventRow(): MemoWithEventRow = MemoWithEventRow(
+    id = getLong("id"),
+    eventId = getLong("event_id"),
+    content = getString("content"),
+    createdAt = getTimestamp("created_at")?.toInstant(),
+    updatedAt = getTimestamp("updated_at")?.toInstant(),
+
+    eventTitle = getString("event_title"),
+    applyEnd = getTimestamp("apply_end")?.toLocalDateTime(),
+    orgId = getLongOrNull("org_id"),
+    orgName = getString("org_name"),
+    isBookmarked = getBoolean("is_bookmarked"),
+)

--- a/hangsha/src/main/kotlin/com/team1/hangsha/memo/service/MemoService.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/memo/service/MemoService.kt
@@ -4,10 +4,13 @@ import com.team1.hangsha.common.error.DomainException
 import com.team1.hangsha.common.error.ErrorCode
 import com.team1.hangsha.event.repository.EventRepository
 import com.team1.hangsha.memo.dto.*
+import com.team1.hangsha.memo.dto.core.MemoOrganizationResponse
 import com.team1.hangsha.memo.dto.core.MemoResponse
 import com.team1.hangsha.memo.dto.core.MemoTagResponse
+import com.team1.hangsha.memo.dto.core.MemoWithEventResponse
 import com.team1.hangsha.memo.model.Memo
 import com.team1.hangsha.memo.model.MemoTagRef
+import com.team1.hangsha.memo.repository.MemoQueryRepository
 import com.team1.hangsha.memo.repository.MemoRepository
 import com.team1.hangsha.tag.model.Tag
 import com.team1.hangsha.tag.repository.TagRepository
@@ -19,6 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 @Service
 class MemoService(
     private val memoRepository: MemoRepository,
+    private val memoQueryRepository: MemoQueryRepository,
     private val tagRepository: TagRepository,
     private val eventRepository: EventRepository,
     private val objectMapper: ObjectMapper,
@@ -121,14 +125,30 @@ class MemoService(
     }
 
     @Transactional(readOnly = true)
-    fun getMyMemos(userId: Long): List<MemoResponse> {
-        val memos = memoRepository.findAllByUserIdOrderByCreatedAtDesc(userId)
+    fun getMyMemos(userId: Long): List<MemoWithEventResponse> {
+        val rows = memoQueryRepository.findMemosWithEventByUserId(userId)
+        if (rows.isEmpty()) return emptyList()
 
-        return memos.map { memo ->
-            val eventTitle = eventRepository.findById(memo.eventId)
-                .map { it.title }
-                .orElse("Unknown Event")
-            mapToMemoResponse(memo, eventTitle)
+        val tagsByMemoId = memoQueryRepository.findTagsByMemoIds(rows.map { it.id })
+            .groupBy({ it.memoId }, { MemoTagResponse(id = it.tagId, name = it.tagName) })
+
+        return rows.map { row ->
+            MemoWithEventResponse(
+                id = row.id,
+                eventId = row.eventId,
+                eventTitle = row.eventTitle ?: "Unknown Event",
+                content = row.content,
+                tags = tagsByMemoId[row.id].orEmpty(),
+                createdAt = row.createdAt,
+                updatedAt = row.updatedAt,
+                applyEnd = row.applyEnd,
+                organization = if (row.orgId != null && row.orgName != null) {
+                    MemoOrganizationResponse(id = row.orgId, name = row.orgName)
+                } else {
+                    null
+                },
+                isBookmarked = row.isBookmarked,
+            )
         }
     }
 


### PR DESCRIPTION

## #️⃣ 연관된 이슈

#180 

## 📝 작업 내용

MemoController에서, /api/v1/memos 엔드포인트에 대한 핸들러인 getMeyMemos에 대한 응답 데이터를 수정하였음
기존 내 메모 목록 응답은 
```
data class MemoResponse(
    val id: Long,
    val eventId: Long,
    val eventTitle: String,
    val content: String,
    val tags: List<MemoTagResponse>,
    val createdAt: Instant?,
    val updatedAt: Instant?
)
```
이었는데 클라이언트 측에서 
- applyEnd: D-Day 계산 기준
- organization: 주최기관
- isBookmarked: 현재 사용자의 북마크 여부
데이터가 각 메모마다 추가로 필요하다고 하여 응답데이터가 이를 포함하도록 수정함
```
/** 메모 목록 조회용. 메모에 달린 행사 정보를 함께 내려준다. */
data class MemoWithEventResponse(
    val id: Long,
    val eventId: Long,
    val eventTitle: String,
    val content: String,
    val tags: List<MemoTagResponse>,
    val createdAt: Instant?,
    val updatedAt: Instant?,

    /** D-Day 계산 기준. 행사가 없거나 마감일 미정이면 null */
    val applyEnd: LocalDateTime?,
    /** 주최기관 미분류이면 null */
    val organization: MemoOrganizationResponse?,
    val isBookmarked: Boolean
)
```




## ✅ 체크리스트
- [x] 로컬에서 정상 동작 확인
- [x] 기존 기능에 영향 없음
- [x] 테스트 통과 (또는 테스트 없음)
- [ ] 브레이킹 체인지 여부 확인

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
