### PR TITLE
검색 페이지에서 검색 결과에 대한 종류/기관/현황 필터링

### DIFF
--- a/hangsha/src/main/kotlin/com/team1/hangsha/event/controller/EventController.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/event/controller/EventController.kt
@@ -99,11 +99,17 @@ class EventController(
         @RequestParam("query") query: String,
         @RequestParam("page", defaultValue = "1") page: Int,
         @RequestParam("size", defaultValue = "20") size: Int,
+        @RequestParam("statusId", required = false) statusIds: List<Long>?,
+        @RequestParam("eventTypeId", required = false) eventTypeIds: List<Long>?,
+        @RequestParam("orgId", required = false) orgIds: List<Long>?,
     ): SearchEventResponse =
         eventService.search(
             query = query,
             page = page,
             size = size,
+            statusIds = statusIds,
+            eventTypeIds = eventTypeIds,
+            orgIds = orgIds,
             userId = user?.id,
         )
 }

--- a/hangsha/src/main/kotlin/com/team1/hangsha/event/repository/EventQueryRepository.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/event/repository/EventQueryRepository.kt
@@ -243,15 +243,34 @@ class EventQueryRepository(
         return jdbc.query(sql, params) { rs, _ -> rs.toEvent() }
     }
 
-    fun findVisibleByIds(ids: List<Long>): List<Event> {
+    fun findVisibleByIds(
+        ids: List<Long>,
+        statusIds: List<Long>? = null,
+        eventTypeIds: List<Long>? = null,
+        orgIds: List<Long>? = null,
+    ): List<Event> {
         if (ids.isEmpty()) return emptyList()
-        val sql = """
+        val sql = buildString {
+            append(
+                """
             SELECT e.* FROM events e
             WHERE e.id IN (:ids)
               AND e.admin_deleted = false
-            ORDER BY COALESCE(e.event_start, e.apply_start) DESC, e.id DESC
-        """.trimIndent()
-        return jdbc.query(sql, mapOf("ids" to ids)) { rs, _ -> rs.toEvent() }
+            """.trimIndent()
+            )
+            if (!statusIds.isNullOrEmpty()) append("\n  AND status_id IN (:statusIds)")
+            if (!eventTypeIds.isNullOrEmpty()) append("\n  AND event_type_id IN (:eventTypeIds)")
+            if (!orgIds.isNullOrEmpty()) append("\n  AND org_id IN (:orgIds)")
+
+            append("\nORDER BY COALESCE(e.event_start, e.apply_start) DESC, e.id DESC")
+        }
+
+        val params = mutableMapOf<String, Any>("ids" to ids)
+        if (!statusIds.isNullOrEmpty()) params["statusIds"] = statusIds
+        if (!eventTypeIds.isNullOrEmpty()) params["eventTypeIds"] = eventTypeIds
+        if (!orgIds.isNullOrEmpty()) params["orgIds"] = orgIds
+
+        return jdbc.query(sql, params) { rs, _ -> rs.toEvent() }
     }
 }
 

--- a/hangsha/src/main/kotlin/com/team1/hangsha/event/service/EventService.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/event/service/EventService.kt
@@ -212,6 +212,9 @@ class EventService(
         query: String,
         page: Int,
         size: Int,
+        statusIds: List<Long>?,
+        eventTypeIds: List<Long>?,
+        orgIds: List<Long>?,
         userId: Long?,
     ): SearchEventResponse {
         val q = query.trim()
@@ -222,14 +225,18 @@ class EventService(
         /**
          * TODO :
          * 2. sorting
-         * 3. categrory filtering
          */
 
         val safePage = max(1, page)
         val safeSize = max(1, size)
         val offset = (safePage - 1) * safeSize
 
-        val allEvents = eventQueryRepository.findVisibleByIds(result.eventIds)
+        val allEvents = eventQueryRepository.findVisibleByIds(
+            ids = result.eventIds,
+            statusIds = statusIds,
+            eventTypeIds = eventTypeIds,
+            orgIds = orgIds,
+        )
 
         // main_content_html 태그 제거 텍스트 캐시: 제외 필터와 하이라이트에서 재사용 (이벤트당 최대 1회 파싱)
         val contentTextCache = HashMap<Long, String?>()


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#181

## 📝 작업 내용
검색 페이지에서 검색 결과에 대한 종류/기관/현황 관련 필터링을 적용하였습니다
적용 방식은 행사 상세 데이터들을 DB에 조회 시에 type/org/statusId 가 해당되는 것들만 함께 가져오는 식입니다.


## ✅ 체크리스트
- [x] 로컬에서 정상 동작 확인
- [x] 기존 기능에 영향 없음
- [x] 테스트 통과 (또는 테스트 없음)
- [ ] 브레이킹 체인지 여부 확인

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
