### PR TITLE
feat: 비로그인 사용자도 버그 리포트 제출 가능하도록

### DIFF
--- a/hangsha/src/main/kotlin/com/team1/hangsha/bugreport/controller/BugReportController.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/bugreport/controller/BugReportController.kt
@@ -23,13 +23,13 @@ class BugReportController(
     @PostMapping
     @Operation(
         summary = "버그 리포트 등록",
-        description = "로그인 사용자의 버그 리포트를 저장하고, 알림 채널로 전송을 시도합니다. 알림 전송 실패여도 저장은 성공 처리됩니다."
+        description = "버그 리포트를 저장하고, 알림 채널로 전송을 시도합니다. 비로그인 사용자도 제출할 수 있으며, 이 경우 작성자는 익명으로 기록됩니다. 알림 전송 실패여도 저장은 성공 처리됩니다."
     )
     fun create(
-        @Parameter(hidden = true) @LoggedInUser user: User,
+        @Parameter(hidden = true) @LoggedInUser user: User?,
         @Valid @RequestBody req: CreateBugReportRequest,
     ): ResponseEntity<CreateBugReportResponse> {
-        val id = bugReportService.create(req, user.id)
+        val id = bugReportService.create(req, user?.id)
         return ResponseEntity.status(HttpStatus.CREATED)
             .body(CreateBugReportResponse(id = id))
     }

--- a/hangsha/src/main/kotlin/com/team1/hangsha/config/SecurityConfig.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/config/SecurityConfig.kt
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.web.servlet.FilterRegistrationBean
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpMethod
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.http.SessionCreationPolicy
@@ -80,6 +81,8 @@ class SecurityConfig(
                         "/login/oauth2/code/**",
                         "/error",
                     ).permitAll()
+                    // 버그 리포트 등록 (비로그인 사용자도 제출 가능, 조회 계열은 계속 인증 필요)
+                    .requestMatchers(HttpMethod.POST, "/api/v1/bug-reports").permitAll()
                     .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
                     .anyRequest().authenticated()
             }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

>

## 📝 작업 내용

비로그인 사용자도 버그 리포트를 제출할 수 있도록 토큰을 필수에서 선택으로 낮췄습니다. 행사 상세 사이드 패널의 '행사 정보 오류 제보' 버튼과 짝이 되는 변경입니다.

**`SecurityConfig.kt`**
```kotlin
.requestMatchers(HttpMethod.POST, "/api/v1/bug-reports").permitAll()
```
`anyRequest().authenticated()`에 걸려 401이 나던 지점입니다. 경로 전체가 아니라 `HttpMethod.POST`로 한정해서, 추후 리포트 조회(GET) 엔드포인트가 생겨도 자동으로 공개되지 않도록 했습니다.

**`BugReportController.kt`**
```kotlin
- @LoggedInUser user: User,               →  @LoggedInUser user: User?,
- bugReportService.create(req, user.id)   →  bugReportService.create(req, user?.id)
```
`UserArgumentResolver`는 이미 `User?`를 리턴합니다. SecurityConfig만 열면 null이 컨트롤러까지 들어와 Kotlin non-null 체크에 걸려 **401이 500으로 바뀔 뿐**이라, 이 수정이 함께 필요합니다.

Swagger `description` 문구도 비로그인 제출 가능하도록 갱신했습니다.

**변경하지 않은 것** — 컨트롤러 아래 레이어는 이미 익명 리포트를 받을 준비가 되어 있었습니다.
- `bug_reports.user_id` — `NULL` 허용 + FK `ON DELETE SET NULL`
- `BugReport.userId: Long?`, `BugReportService.create(req, userId: Long?)`
- `DiscordWebhookBugReportNotifier` — `report.userId?.toString() ?: "anonymous"`

## ✅ 체크리스트
- [x] 로컬에서 정상 동작 확인
- [x] 기존 기능에 영향 없음
- [x] 테스트 통과 (또는 테스트 없음)
- [x] 브레이킹 체인지 여부 확인

**동작 확인** — 로컬 백엔드에 실제 요청을 보내고 DB를 직접 확인했습니다.

| 요청 | 응답 | `bug_reports.user_id` |
|---|---|---|
| 토큰 없음 | 201 | `NULL` |
| 유효 토큰 | 201 | 해당 유저 id |
| 깨진 토큰 | 201 | `NULL` |

변경 전이라면 첫 번째가 401입니다. 추가로 로컬 백엔드를 dev DB(`hangsha_dev`)에 연결한 상태에서 프론트의 행사 상세 사이드 패널 오류 제보 플로우를 수동 검증했습니다. Flyway는 `Schema is up to date. No migration necessary.`로 dev 스키마를 변경하지 않았습니다.

**기존 기능 영향 없음** — `JwtAuthenticationFilter`는 인가 규칙과 무관하게 항상 먼저 실행되며 토큰이 있으면 `userId`를 request attribute에 심습니다. permitAll로 바뀌어도 로그인 사용자의 작성자 기록은 그대로 유지됩니다(위 표 2행).

**테스트** — 별도 테스트 코드는 추가하지 않았습니다.

**브레이킹 체인지 없음** — 기존 요청 형식·응답 형식 변동 없이 허용 범위만 넓힙니다.

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
