### PR TITLE
memo 목록 응답에서 orgID 대신 eventTypeId 넘겨주기

### DIFF
--- a/hangsha/src/main/kotlin/com/team1/hangsha/memo/dto/core/MemoDto.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/memo/dto/core/MemoDto.kt
@@ -29,8 +29,8 @@ data class MemoWithEventResponse(
     val id: Long,
     val eventId: Long,
     val eventTitle: String,
-    /** 메모가 달린 행사의 주최기관 카테고리 ID (events.org_id). 미분류이면 null */
-    val categoryId: Long?,
+    /** 메모가 달린 행사의 유형 카테고리 ID (events.event_type_id). 미분류이면 null */
+    val eventTypeId: Long?,
     val content: String,
     val tags: List<MemoTagResponse>,
     val createdAt: Instant?,

--- a/hangsha/src/main/kotlin/com/team1/hangsha/memo/repository/MemoQueryRepository.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/memo/repository/MemoQueryRepository.kt
@@ -15,7 +15,7 @@ data class MemoWithEventRow(
     val updatedAt: Instant?,
 
     val eventTitle: String?,
-    val categoryId: Long?,
+    val eventTypeId: Long?,
     val applyEnd: LocalDateTime?,
     val orgId: Long?,
     val orgName: String?,
@@ -44,7 +44,7 @@ class MemoQueryRepository(
                    m.created_at     AS created_at,
                    m.updated_at     AS updated_at,
                    e.title          AS event_title,
-                   e.org_id         AS category_id,
+                   e.event_type_id  AS event_type_id,
                    e.apply_end      AS apply_end,
                    c.id             AS org_id,
                    c.name           AS org_name,
@@ -94,7 +94,7 @@ private fun ResultSet.toMemoWithEventRow(): MemoWithEventRow = MemoWithEventRow(
     updatedAt = getTimestamp("updated_at")?.toInstant(),
 
     eventTitle = getString("event_title"),
-    categoryId = getLongOrNull("category_id"),
+    eventTypeId = getLongOrNull("event_type_id"),
     applyEnd = getTimestamp("apply_end")?.toLocalDateTime(),
     orgId = getLongOrNull("org_id"),
     orgName = getString("org_name"),

--- a/hangsha/src/main/kotlin/com/team1/hangsha/memo/service/MemoService.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/memo/service/MemoService.kt
@@ -137,7 +137,7 @@ class MemoService(
                 id = row.id,
                 eventId = row.eventId,
                 eventTitle = row.eventTitle ?: "Unknown Event",
-                categoryId = row.categoryId,
+                eventTypeId = row.eventTypeId,
                 content = row.content,
                 tags = tagsByMemoId[row.id].orEmpty(),
                 createdAt = row.createdAt,

--- a/hangsha/src/main/resources/static/openapi.yaml
+++ b/hangsha/src/main/resources/static/openapi.yaml
@@ -503,7 +503,7 @@ components:
 
     MemoWithEventResponse:
       type: object
-      required: [ id, eventId, eventTitle, categoryId, content, tags, isBookmarked ]
+      required: [ id, eventId, eventTitle, eventTypeId, content, tags, isBookmarked ]
       properties:
         id:
           type: integer
@@ -516,11 +516,11 @@ components:
         eventTitle:
           type: string
           example: "EV1"
-        categoryId:
+        eventTypeId:
           type: integer
           format: int64
           nullable: true
-          description: 메모가 달린 행사의 주최기관 카테고리 ID(events.org_id). 미분류이면 null
+          description: 메모가 달린 행사의 유형 카테고리 ID(events.event_type_id). 미분류이면 null
           example: 12
         content:
           type: string


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#180

## 📝 작업 내용

eventTypeId를 주어야 했는데 orgID를 잘못 주고 있어서 이를 다시 고침 

## ✅ 체크리스트
- [ ] 로컬에서 정상 동작 확인
- [ ] 기존 기능에 영향 없음
- [ ] 테스트 통과 (또는 테스트 없음)
- [ ] 브레이킹 체인지 여부 확인

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
