### PR TITLE
fix: 이메일 인증번호 유효시간 30분 → 10분

### DIFF
--- a/hangsha/src/main/kotlin/com/team1/hangsha/user/verification/EmailVerificationProperties.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/user/verification/EmailVerificationProperties.kt
@@ -5,8 +5,8 @@ import java.time.Duration
 
 @ConfigurationProperties(prefix = "email.verification")
 data class EmailVerificationProperties(
-    /** 인증번호 유효시간. 화면의 카운트다운(30:00)과 같은 값이어야 한다. */
-    val ttl: Duration = Duration.ofMinutes(30),
+    /** 인증번호 유효시간. 화면의 카운트다운(10:00)과 같은 값이어야 한다. */
+    val ttl: Duration = Duration.ofMinutes(10),
     /** "인증번호 다시 받기" 재발송 쿨다운. 발송 한도를 한 명이 소진하는 것을 막는다. */
     val resendCooldown: Duration = Duration.ofSeconds(60),
     /** 인증번호 입력 허용 횟수. 초과하면 폐기하고 재발송을 요구한다. */

--- a/hangsha/src/main/resources/application.yml
+++ b/hangsha/src/main/resources/application.yml
@@ -94,7 +94,7 @@ email:
     from-address: hangsha@wafflestudio.com
     from-name: 행샤
   verification:
-    ttl: 30m                  # 화면 카운트다운(30:00)과 같은 값
+    ttl: 10m                  # 화면 카운트다운(10:00)과 같은 값
     resend-cooldown: 60s
     max-attempts: 5
     code-length: 6


### PR DESCRIPTION
## 변경 내용

회원가입 이메일 인증번호의 유효시간을 30분에서 10분으로 줄입니다. (#177 후속)

| 프로퍼티 | 이전 | 이후 |
|---|---|---|
| `email.verification.ttl` | 30m | **10m** |
| `email.verification.signup-token-ttl` | 30m | 30m (변경 없음) |

- `application.yml` 값과 `EmailVerificationProperties`의 기본값을 함께 맞췄습니다.
- 메일 본문의 "N분 이내에 입력해주세요"(`OciEmailSender`)는 이 값을 그대로 쓰므로 자동으로 10분으로 바뀝니다.

## signupToken TTL은 왜 그대로인가

두 TTL은 역할이 다릅니다.

- `ttl` — 메일로 보낸 **6자리 숫자 코드**의 수명. 무작위 대입이 가능한 값이라 노출 시간이 짧을수록 안전합니다. (`maxAttempts: 5`와 함께 작동)
- `signup-token-ttl` — 인증 통과 후 발급하는 **UUID 증표**의 수명. 추측 불가능해서 대입 위험이 없고, 이 값이 정하는 건 사용자가 비밀번호·닉네임 입력을 마칠 시간입니다. 줄이면 폼 작성 중 만료돼 이메일 인증을 다시 하게 되는 불편만 생깁니다.

즉 앞쪽은 줄이면 보안이 개선되고, 뒤쪽은 줄이면 사용성만 나빠지므로 앞쪽만 조정했습니다.

## 참고

웹에는 아직 인증 화면/카운트다운 구현이 없어 프론트 동시 수정 대상은 없습니다. 화면이 붙을 때 카운트다운을 `10:00`으로 맞춰야 합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)