### PR TITLE
feat: 카테고리 스키마 3개로 분리 

### DIFF
--- a/hangsha/common/src/main/kotlin/com/team1/hangsha/category/model/EventStatus.kt
+++ b/hangsha/common/src/main/kotlin/com/team1/hangsha/category/model/EventStatus.kt
@@ -1,0 +1,11 @@
+package com.team1.hangsha.category.model
+
+import org.springframework.data.annotation.Id
+import org.springframework.data.relational.core.mapping.Table
+
+@Table("event_statuses")
+data class EventStatus(
+    @Id val id: Long? = null,
+    val name: String,
+    val sortOrder: Int = 0,
+)

--- a/hangsha/common/src/main/kotlin/com/team1/hangsha/category/model/EventType.kt
+++ b/hangsha/common/src/main/kotlin/com/team1/hangsha/category/model/EventType.kt
@@ -1,0 +1,11 @@
+package com.team1.hangsha.category.model
+
+import org.springframework.data.annotation.Id
+import org.springframework.data.relational.core.mapping.Table
+
+@Table("event_types")
+data class EventType(
+    @Id val id: Long? = null,
+    val name: String,
+    val sortOrder: Int = 0,
+)

--- a/hangsha/common/src/main/kotlin/com/team1/hangsha/category/model/Organization.kt
+++ b/hangsha/common/src/main/kotlin/com/team1/hangsha/category/model/Organization.kt
@@ -1,0 +1,14 @@
+package com.team1.hangsha.category.model
+
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.Id
+import org.springframework.data.relational.core.mapping.Table
+import java.time.Instant
+
+@Table("organizations")
+data class Organization(
+    @Id val id: Long? = null,
+    val name: String,
+    val sortOrder: Int = 0,
+    @CreatedDate val createdAt: Instant? = null,
+)

--- a/hangsha/common/src/main/kotlin/com/team1/hangsha/category/repository/EventStatusRepository.kt
+++ b/hangsha/common/src/main/kotlin/com/team1/hangsha/category/repository/EventStatusRepository.kt
@@ -1,0 +1,9 @@
+package com.team1.hangsha.category.repository
+
+import com.team1.hangsha.category.model.EventStatus
+import org.springframework.data.repository.CrudRepository
+
+interface EventStatusRepository : CrudRepository<EventStatus, Long> {
+    fun findByName(name: String): EventStatus?
+    fun findAllByOrderBySortOrderAsc(): List<EventStatus>
+}

--- a/hangsha/common/src/main/kotlin/com/team1/hangsha/category/repository/EventTypeRepository.kt
+++ b/hangsha/common/src/main/kotlin/com/team1/hangsha/category/repository/EventTypeRepository.kt
@@ -1,0 +1,9 @@
+package com.team1.hangsha.category.repository
+
+import com.team1.hangsha.category.model.EventType
+import org.springframework.data.repository.CrudRepository
+
+interface EventTypeRepository : CrudRepository<EventType, Long> {
+    fun findByName(name: String): EventType?
+    fun findAllByOrderBySortOrderAsc(): List<EventType>
+}

--- a/hangsha/common/src/main/kotlin/com/team1/hangsha/category/repository/OrganizationRepository.kt
+++ b/hangsha/common/src/main/kotlin/com/team1/hangsha/category/repository/OrganizationRepository.kt
@@ -1,0 +1,20 @@
+package com.team1.hangsha.category.repository
+
+import com.team1.hangsha.category.model.Organization
+import org.springframework.data.jdbc.repository.query.Query
+import org.springframework.data.repository.CrudRepository
+
+interface OrganizationRepository : CrudRepository<Organization, Long> {
+    fun findByName(name: String): Organization?
+    fun findAllByOrderBySortOrderAsc(): List<Organization>
+
+    @Query("SELECT COALESCE(MAX(sort_order), 0) FROM organizations")
+    fun findMaxSortOrder(): Int
+
+    @Query("""
+        SELECT o.* FROM organizations o
+        WHERE (SELECT COUNT(*) FROM events e WHERE e.org_id = o.id AND e.admin_deleted = FALSE) >= :minimumEventCount
+        ORDER BY o.sort_order ASC
+    """)
+    fun findAllWithMinimumEventCount(minimumEventCount: Int): List<Organization>
+}

--- a/hangsha/common/src/main/kotlin/com/team1/hangsha/event/service/EventSyncService.kt
+++ b/hangsha/common/src/main/kotlin/com/team1/hangsha/event/service/EventSyncService.kt
@@ -4,9 +4,10 @@ import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.ObjectNode
-import com.team1.hangsha.category.model.Category
-import com.team1.hangsha.category.repository.CategoryGroupRepository
-import com.team1.hangsha.category.repository.CategoryRepository
+import com.team1.hangsha.category.model.Organization
+import com.team1.hangsha.category.repository.EventTypeRepository
+import com.team1.hangsha.category.repository.OrganizationRepository
+import com.team1.hangsha.category.repository.EventStatusRepository
 import com.team1.hangsha.common.error.DomainException
 import com.team1.hangsha.common.error.ErrorCode
 import com.team1.hangsha.event.dto.core.CrawledDetailSession
@@ -31,8 +32,9 @@ import java.time.ZoneId
 class EventSyncService(
     private val objectMapper: ObjectMapper,
     private val eventRepository: EventRepository,
-    private val categoryGroupRepository: CategoryGroupRepository,
-    private val categoryRepository: CategoryRepository,
+    private val eventStatusRepository: EventStatusRepository,
+    private val eventTypeRepository: EventTypeRepository,
+    private val organizationRepository: OrganizationRepository,
     private val outboxWriter: EventSearchOutboxWriter,
 ) {
 
@@ -43,10 +45,6 @@ class EventSyncService(
      */
     @Transactional
     fun sync(events: List<CrawledProgramEvent>): SyncResult {
-        val statusGroupId = requireGroupId("모집현황")
-        val typeGroupId = requireGroupId("프로그램 유형")
-        val orgGroupId = requireGroupId("주체기관")
-
         var upserted = 0
         var skipped = 0
 
@@ -60,10 +58,10 @@ class EventSyncService(
             //}
 
             val orgName = e.majorTypes.getOrNull(0)?.trim()?.takeIf { it.isNotBlank() }
-            val orgId = orgName?.let { getOrCreateCategoryId(orgGroupId, it) }
+            val orgId = orgName?.let { getOrCreateOrganizationId(it) }
             val typeName = normalizeProgramType(e)
 
-            val eventTypeId = typeName?.let { findCategoryId(typeGroupId, it) }
+            val eventTypeId = typeName?.let { eventTypeRepository.findByName(it)?.id }
 
             val applyStart = e.applyStart?.let { dateStart(it) }
             val applyEnd = e.applyEnd?.let { dateEnd(it) }
@@ -146,7 +144,7 @@ class EventSyncService(
                     eventEnd = eventEnd,
                     now = now,
                 )
-                val statusId = statusName?.let { findCategoryId(statusGroupId, it) }
+                val statusId = statusName?.let { eventStatusRepository.findByName(it)?.id }
 
                 val crawledTagsJson = if (cleanedTags.isEmpty()) {
                     null
@@ -203,16 +201,15 @@ class EventSyncService(
 
     @Transactional
     fun openStartedWaitingEvents(): Int {
-        val statusGroupId = requireGroupId("모집현황")
-        val waitingStatusId = findCategoryId(statusGroupId, "모집대기")
+        val waitingStatusId = eventStatusRepository.findByName("모집대기")?.id
             ?: throw DomainException(
                 ErrorCode.INTERNAL_ERROR,
-                "Category not found. group=모집현황, name=모집대기"
+                "Recruitment status not found. name=모집대기"
             )
-        val recruitingStatusId = findCategoryId(statusGroupId, "모집중")
+        val recruitingStatusId = eventStatusRepository.findByName("모집중")?.id
             ?: throw DomainException(
                 ErrorCode.INTERNAL_ERROR,
-                "Category not found. group=모집현황, name=모집중"
+                "Recruitment status not found. name=모집중"
             )
 
         return eventRepository.openStartedEventsByStatus(
@@ -224,24 +221,21 @@ class EventSyncService(
 
     @Transactional
     fun closeExpiredRecruitingEvents(): Int {
-        // @TODO: 굉장히 하드코딩이긴 한데...
-        val statusGroupId = requireGroupId("모집현황")
-
-        val recruitingStatusId = findCategoryId(statusGroupId, "모집중")
+        val recruitingStatusId = eventStatusRepository.findByName("모집중")?.id
             ?: throw DomainException(
                 ErrorCode.INTERNAL_ERROR,
-                "Category not found. group=모집현황, name=모집중"
+                "Recruitment status not found. name=모집중"
             )
 
-        val closedStatusId = findCategoryId(statusGroupId, "모집마감")
+        val closedStatusId = eventStatusRepository.findByName("모집마감")?.id
             ?: throw DomainException(
                 ErrorCode.INTERNAL_ERROR,
-                "Category not found. group=모집현황, name=모집마감"
+                "Recruitment status not found. name=모집마감"
             )
 
         val now = LocalDateTime.now(ZoneId.of("Asia/Seoul"))
 
-        val unknownStatusId = findCategoryId(statusGroupId, "상태 미제공")
+        val unknownStatusId = eventStatusRepository.findByName("상태 미제공")?.id
 
         val closedRecruiting = eventRepository.closeExpiredEventsByStatus(
             statusId = recruitingStatusId,
@@ -258,20 +252,6 @@ class EventSyncService(
 
         return closedRecruiting + closedUnknown
     }
-
-    private fun requireGroupId(name: String): Long {
-        val group = categoryGroupRepository.findByName(name)
-            ?: throw DomainException(ErrorCode.CATEGORY_GROUP_NOT_FOUND)
-
-        return group.id
-            ?: throw DomainException(
-                ErrorCode.INTERNAL_ERROR,
-                "CategoryGroup.id is null (unexpected). name=$name"
-            )
-    }
-
-    private fun findCategoryId(groupId: Long, name: String): Long? =
-        categoryRepository.findByGroupIdAndName(groupId, name)?.id
 
     private fun resolveApplyLink(e: CrawledProgramEvent): String {
         e.applyLink?.trim()?.takeIf { it.isNotBlank() }?.let { return it }
@@ -321,24 +301,23 @@ class EventSyncService(
     private fun dateEnd(ymd: String): LocalDateTime =
         LocalDate.parse(ymd).atTime(23, 59, 59)
 
-    private fun getOrCreateCategoryId(groupId: Long, rawName: String): Long {
+    private fun getOrCreateOrganizationId(rawName: String): Long {
         val name = rawName.trim()
-        categoryRepository.findByGroupIdAndName(groupId, name)?.id?.let { return it }
+        organizationRepository.findByName(name)?.id?.let { return it }
 
-        val nextSortOrder = runCatching { categoryRepository.findMaxSortOrderByGroupId(groupId) + 1 }
+        val nextSortOrder = runCatching { organizationRepository.findMaxSortOrder() + 1 }
             .getOrDefault(1)
 
         return try {
-            val saved = categoryRepository.save(
-                Category(
-                    groupId = groupId,
+            val saved = organizationRepository.save(
+                Organization(
                     name = name,
                     sortOrder = nextSortOrder
                 )
             )
             saved.id ?: throw DomainException(ErrorCode.CATEGORY_CREATE_FAILED)
         } catch (e: DuplicateKeyException) {
-            categoryRepository.findByGroupIdAndName(groupId, name)?.id ?: throw e
+            organizationRepository.findByName(name)?.id ?: throw e
         }
     }
 
@@ -547,9 +526,7 @@ class EventSyncService(
             eventEnd = req.eventEnd,
         )
         val organization = req.organization?.trim()?.takeIf { it.isNotBlank() }
-        val resolvedOrgId = req.orgId ?: organization?.let {
-            getOrCreateCategoryId(requireGroupId("주체기관"), it)
-        }
+        val resolvedOrgId = req.orgId ?: organization?.let(::getOrCreateOrganizationId)
 
         val units = if (req.sessions.isEmpty()) {
             listOf(Triple(req.eventStart, req.eventEnd, req.location?.trim()))

--- a/hangsha/common/src/main/kotlin/com/team1/hangsha/user/model/InterestCategoryType.kt
+++ b/hangsha/common/src/main/kotlin/com/team1/hangsha/user/model/InterestCategoryType.kt
@@ -1,0 +1,3 @@
+package com.team1.hangsha.user.model
+
+enum class InterestCategoryType { EVENT_STATUS, EVENT_TYPE, ORGANIZATION }

--- a/hangsha/src/main/kotlin/com/team1/hangsha/category/controller/CategoryController.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/category/controller/CategoryController.kt
@@ -1,30 +1,26 @@
 package com.team1.hangsha.category.controller
 
+import com.team1.hangsha.category.dto.ListCategoryItemsResponse
 import com.team1.hangsha.category.service.CategoryService
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-import com.team1.hangsha.category.dto.ListCategoryGroupWithCategoriesResponse
-import com.team1.hangsha.category.dto.ListOrgCategoriesResponse
 
 @Tag(name = "Categories")
 @RequestMapping("/api/v1")
 @RestController
-class CategoryController(
-    private val categoryService: CategoryService
-) {
-    @Operation(summary = "카테고리 그룹 + 카테고리 목록")
-    @GetMapping("/category-groups/with-categories")
-    fun getCategoryGroupsWithCategories(): ListCategoryGroupWithCategoriesResponse {
-        val items = categoryService.getCategoryGroupsWithCategories()
-        return ListCategoryGroupWithCategoriesResponse(items)
-    }
-    @Operation(summary = "주체기관 카테고리 목록 조회")
-    @GetMapping("/categories/orgs")
-    fun getOrgCategories(): ListOrgCategoriesResponse {
-        val items = categoryService.getOrgCategories()
-        return ListOrgCategoriesResponse(items)
-    }
+class CategoryController(private val categoryService: CategoryService) {
+    @Operation(summary = "행사 상태 목록 조회")
+    @GetMapping("/event-statuses")
+    fun getEventStatuses() = ListCategoryItemsResponse(categoryService.getEventStatuses())
+
+    @Operation(summary = "프로그램 유형 목록 조회")
+    @GetMapping("/event-types")
+    fun getEventTypes() = ListCategoryItemsResponse(categoryService.getEventTypes())
+
+    @Operation(summary = "주체기관 목록 조회")
+    @GetMapping("/organizations")
+    fun getOrganizations() = ListCategoryItemsResponse(categoryService.getOrganizations())
 }

--- a/hangsha/src/main/kotlin/com/team1/hangsha/category/dto/ListCategoryItemsResponse.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/category/dto/ListCategoryItemsResponse.kt
@@ -1,0 +1,5 @@
+package com.team1.hangsha.category.dto
+
+import com.team1.hangsha.category.dto.core.CategoryItemDto
+
+data class ListCategoryItemsResponse(val items: List<CategoryItemDto>)

--- a/hangsha/src/main/kotlin/com/team1/hangsha/category/dto/core/CategoryItemDto.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/category/dto/core/CategoryItemDto.kt
@@ -1,0 +1,3 @@
+package com.team1.hangsha.category.dto.core
+
+data class CategoryItemDto(val id: Long, val name: String, val sortOrder: Int)

--- a/hangsha/src/main/kotlin/com/team1/hangsha/category/service/CategoryService.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/category/service/CategoryService.kt
@@ -1,65 +1,26 @@
 package com.team1.hangsha.category.service
 
-import com.team1.hangsha.category.dto.CategoryResponse
-import com.team1.hangsha.category.dto.core.CategoryDto
-import com.team1.hangsha.category.dto.core.CategoryGroupDto
-import com.team1.hangsha.category.repository.CategoryGroupRepository
-import com.team1.hangsha.category.repository.CategoryRepository
-import com.team1.hangsha.common.error.DomainException
-import com.team1.hangsha.common.error.ErrorCode
+import com.team1.hangsha.category.dto.core.CategoryItemDto
+import com.team1.hangsha.category.repository.EventTypeRepository
+import com.team1.hangsha.category.repository.OrganizationRepository
+import com.team1.hangsha.category.repository.EventStatusRepository
 import org.springframework.stereotype.Service
 
 @Service
 class CategoryService(
-    private val categoryGroupRepository: CategoryGroupRepository,
-    private val categoryRepository: CategoryRepository
+    private val eventStatusRepository: EventStatusRepository,
+    private val eventTypeRepository: EventTypeRepository,
+    private val organizationRepository: OrganizationRepository,
 ) {
-    fun getCategoryGroupsWithCategories(): List<CategoryResponse> {
-        val groups = categoryGroupRepository.findAllByOrderBySortOrderAsc()
-
-        return groups.map { g ->
-            val groupId = g.id
-                ?: throw DomainException(ErrorCode.INTERNAL_ERROR, "CategoryGroup.id is null (unexpected)")
-                // INTERNAL_ERROR를 쓰는 이유: category 정보는 기본으로 seed_categories.sql에 의해 자동으로 주입되어야 하기 때문
-
-            val categories = categoryRepository.findAllByGroupIdOrderBySortOrderAsc(groupId)
-                .map { c ->
-                    CategoryDto(
-                        id = c.id ?: throw DomainException(ErrorCode.INTERNAL_ERROR, "Category.id is null (unexpected)"),
-                        groupId = c.groupId,
-                        name = c.name,
-                        sortOrder = c.sortOrder
-                    )
-                }
-
-            CategoryResponse(
-                group = CategoryGroupDto(
-                    id = groupId,
-                    name = g.name,
-                    sortOrder = g.sortOrder
-                ),
-                categories = categories
-            )
-        }
+    fun getEventStatuses(): List<CategoryItemDto> = eventStatusRepository.findAllByOrderBySortOrderAsc().map {
+        CategoryItemDto(requireNotNull(it.id), it.name, it.sortOrder)
     }
 
-    fun getOrgCategories(): List<CategoryDto> {
-        val orgGroup = categoryGroupRepository.findByName("주체기관")
-            ?: throw DomainException(ErrorCode.CATEGORY_GROUP_NOT_FOUND, "\"주체기관\" category_group이 없습니다")
+    fun getEventTypes(): List<CategoryItemDto> = eventTypeRepository.findAllByOrderBySortOrderAsc().map {
+        CategoryItemDto(requireNotNull(it.id), it.name, it.sortOrder)
+    }
 
-        val groupId = orgGroup.id
-            ?: throw DomainException(ErrorCode.INTERNAL_ERROR, "CategoryGroup.id is null (unexpected)")
-
-        return categoryRepository.findAllByGroupIdWithMinimumEventCount(
-            groupId = groupId,
-            minimumEventCount = 2,
-        ).map { c ->
-            CategoryDto(
-                id = c.id ?: throw DomainException(ErrorCode.INTERNAL_ERROR, "Category.id is null (unexpected)"),
-                groupId = c.groupId,
-                name = c.name,
-                sortOrder = c.sortOrder
-            )
-        }
+    fun getOrganizations(): List<CategoryItemDto> = organizationRepository.findAllWithMinimumEventCount(2).map {
+        CategoryItemDto(requireNotNull(it.id), it.name, it.sortOrder)
     }
 }

--- a/hangsha/src/main/kotlin/com/team1/hangsha/config/SecurityConfig.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/config/SecurityConfig.kt
@@ -68,9 +68,10 @@ class SecurityConfig(
                         "/api/v1/events/day/**",
                         "/api/v1/events/search/**",
                         "/api/v1/events/**",
-                        // 주최 기관
-                        "/api/v1/category-groups/**",
-                        "/api/v1/categories/**",
+                        // 카테고리 조회
+                        "/api/v1/event-statuses/**",
+                        "/api/v1/event-types/**",
+                        "/api/v1/organizations/**",
                         // 테스트 페이지 / 로컬 편의
                         "/hangsha-search-test.html",
                         "/api/v1/admin/auth/session",

--- a/hangsha/src/main/kotlin/com/team1/hangsha/event/repository/EventQueryRepository.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/event/repository/EventQueryRepository.kt
@@ -339,11 +339,10 @@ private fun StringBuilder.appendEventOrderBy(userId: Long?) {
     }
 
     val matchedPriorityExpr = """
-        (
-          SELECT MIN(uic.priority)
-          FROM user_interest_categories uic
-          WHERE uic.user_id = :userId
-            AND uic.category_id IN (e.status_id, e.event_type_id, e.org_id)
+        LEAST(
+          COALESCE((SELECT MIN(u.priority) FROM user_interest_event_statuses u WHERE u.user_id = :userId AND u.event_status_id = e.status_id), 2147483647),
+          COALESCE((SELECT MIN(u.priority) FROM user_interest_event_types u WHERE u.user_id = :userId AND u.event_type_id = e.event_type_id), 2147483647),
+          COALESCE((SELECT MIN(u.priority) FROM user_interest_organizations u WHERE u.user_id = :userId AND u.organization_id = e.org_id), 2147483647)
         )
     """.trimIndent()
 
@@ -351,7 +350,7 @@ private fun StringBuilder.appendEventOrderBy(userId: Long?) {
         """
 
         ORDER BY
-          CASE WHEN $matchedPriorityExpr IS NULL THEN 1 ELSE 0 END ASC,
+          CASE WHEN $matchedPriorityExpr = 2147483647 THEN 1 ELSE 0 END ASC,
           $matchedPriorityExpr ASC,
           COALESCE(e.event_start, e.apply_start) ASC,
           e.id ASC

--- a/hangsha/src/main/kotlin/com/team1/hangsha/event/repository/EventQueryRepository.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/event/repository/EventQueryRepository.kt
@@ -340,9 +340,9 @@ private fun StringBuilder.appendEventOrderBy(userId: Long?) {
 
     val matchedPriorityExpr = """
         LEAST(
-          COALESCE((SELECT MIN(u.priority) FROM user_interest_event_statuses u WHERE u.user_id = :userId AND u.event_status_id = e.status_id), 2147483647),
-          COALESCE((SELECT MIN(u.priority) FROM user_interest_event_types u WHERE u.user_id = :userId AND u.event_type_id = e.event_type_id), 2147483647),
-          COALESCE((SELECT MIN(u.priority) FROM user_interest_organizations u WHERE u.user_id = :userId AND u.organization_id = e.org_id), 2147483647)
+          COALESCE((SELECT MIN(u.priority) FROM user_interest_categories u WHERE u.user_id = :userId AND u.event_status_id = e.status_id), 2147483647),
+          COALESCE((SELECT MIN(u.priority) FROM user_interest_categories u WHERE u.user_id = :userId AND u.event_type_id = e.event_type_id), 2147483647),
+          COALESCE((SELECT MIN(u.priority) FROM user_interest_categories u WHERE u.user_id = :userId AND u.organization_id = e.org_id), 2147483647)
         )
     """.trimIndent()
 

--- a/hangsha/src/main/kotlin/com/team1/hangsha/event/service/EventService.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/event/service/EventService.kt
@@ -17,7 +17,7 @@ import com.team1.hangsha.event.repository.EventRepository
 import com.team1.hangsha.search.ManticoreSearchService
 import com.team1.hangsha.search.SearchHighlighter
 import com.team1.hangsha.user.repository.UserExcludedKeywordRepository
-import com.team1.hangsha.user.repository.UserInterestCategoryRepository
+import com.team1.hangsha.user.repository.UserInterestDomainRepository
 import org.jsoup.Jsoup
 import org.springframework.stereotype.Service
 import java.time.LocalDate
@@ -28,7 +28,7 @@ import kotlin.math.max
 class EventService(
     private val eventRepository: EventRepository,
     private val eventQueryRepository: EventQueryRepository,
-    private val userInterestCategoryRepository: UserInterestCategoryRepository,
+    private val userInterestDomainRepository: UserInterestDomainRepository,
     private val bookmarkRepository: BookmarkRepository,
     private val manticoreSearchService: ManticoreSearchService,
     private val userExcludedKeywordRepository: UserExcludedKeywordRepository,
@@ -60,7 +60,7 @@ class EventService(
             applyExcludedKeywords = applyExcludedKeywords,
         )
 
-        val interestPriorityByCategoryId = loadInterestMap(userId)
+        val interestPriorities = loadInterestPriorities(userId)
 
         // 날짜별 버킷: 행사 기간 또는 신청 기간 중 하나라도 그 날과 겹치면 포함
         val buckets = linkedMapOf<LocalDate, MutableList<Event>>().apply {
@@ -111,13 +111,13 @@ class EventService(
             .toSortedMap()
             .mapValues { (_, dayEvents) ->
                 val sorted = dayEvents.sortedWith(
-                    compareBy<Event> { it.matchedInterestPriority(interestPriorityByCategoryId) ?: Int.MAX_VALUE }
+                    compareBy<Event> { it.matchedInterestPriority(interestPriorities) ?: Int.MAX_VALUE }
                         .thenBy { sortStart(it) }
                         .thenBy { it.id ?: Long.MAX_VALUE }
                 )
                 MonthEventResponse.DayBucket(
                     events = sorted.map { e ->
-                        val matchedPriority = e.matchedInterestPriority(interestPriorityByCategoryId)
+                        val matchedPriority = e.matchedInterestPriority(interestPriorities)
                         val isBookmarked = if (auth) bookmarkedIds.contains(requireNotNull(e.id)) else null
                         e.toDto(auth, matchedPriority, isBookmarked)
                     },
@@ -161,8 +161,8 @@ class EventService(
         val event = eventRepository.findVisibleById(eventId)
             ?: throw DomainException(ErrorCode.EVENT_NOT_FOUND)
 
-        val interestPriorityByCategoryId = loadInterestMap(userId)
-        val matchedPriority = event.matchedInterestPriority(interestPriorityByCategoryId)
+        val interestPriorities = loadInterestPriorities(userId)
+        val matchedPriority = event.matchedInterestPriority(interestPriorities)
         val isBookmarked: Boolean? = userId?.let { bookmarkRepository.exists(it, eventId) }
 
         return event.toDetailResponse(auth = userId != null, matchedPriority = matchedPriority, isBookmarked = isBookmarked)
@@ -185,7 +185,7 @@ class EventService(
             date, statusIds, eventTypeIds, orgIds, page, size, userId, applyExcludedKeywords
         )
 
-        val interestPriorityByCategoryId = loadInterestMap(userId)
+        val interestPriorities = loadInterestPriorities(userId)
         val auth = userId != null
         val bookmarkedIds: Set<Long> =
             if (auth) bookmarkRepository.findBookmarkedEventIdsIn(
@@ -194,7 +194,7 @@ class EventService(
             ) else emptySet()
 
         val items = events.map { e ->
-            val matchedPriority = e.matchedInterestPriority(interestPriorityByCategoryId)
+            val matchedPriority = e.matchedInterestPriority(interestPriorities)
             val isBookmarked = if (auth) bookmarkedIds.contains(requireNotNull(e.id)) else null
             e.toDto(auth, matchedPriority, isBookmarked)
         }
@@ -260,14 +260,14 @@ class EventService(
         val events = filteredEvents.drop(offset).take(safeSize)
 
         val auth = userId != null
-        val interestPriorityByCategoryId = loadInterestMap(userId)
+        val interestPriorities = loadInterestPriorities(userId)
         val bookmarkedIds: Set<Long> =
             if (auth) bookmarkRepository.findBookmarkedEventIdsIn(
                 userId!!, events.mapNotNull { it.id }
             ) else emptySet()
 
         val items = events.map { e ->
-            val matchedPriority = e.matchedInterestPriority(interestPriorityByCategoryId)
+            val matchedPriority = e.matchedInterestPriority(interestPriorities)
             val isBookmarked = if (auth) bookmarkedIds.contains(requireNotNull(e.id)) else null
             val rawContent = contentTextOf(e)
 
@@ -329,18 +329,28 @@ class EventService(
     private fun searchSortKey(e: Event): LocalDateTime? =
         e.applyEnd ?: e.eventStart ?: e.applyStart ?: e.eventEnd
 
-    private fun loadInterestMap(userId: Long?): Map<Long, Int> {
-        if (userId == null) return emptyMap()
-        return userInterestCategoryRepository.findAllWithCategoryByUserId(userId)
-            .associate { it.categoryId to it.priority }
+    private fun loadInterestPriorities(userId: Long?): InterestPriorities {
+        if (userId == null) return InterestPriorities()
+        return userInterestDomainRepository.findAllByUserId(userId).fold(InterestPriorities()) { result, row ->
+            when (row.type) {
+                com.team1.hangsha.user.model.InterestCategoryType.EVENT_STATUS -> result.copy(status = result.status + (row.categoryId to row.priority))
+                com.team1.hangsha.user.model.InterestCategoryType.EVENT_TYPE -> result.copy(eventType = result.eventType + (row.categoryId to row.priority))
+                com.team1.hangsha.user.model.InterestCategoryType.ORGANIZATION -> result.copy(organization = result.organization + (row.categoryId to row.priority))
+            }
+        }
     }
 }
 
-private fun Event.matchedInterestPriority(priorityByCategoryId: Map<Long, Int>): Int? {
-    if (priorityByCategoryId.isEmpty()) return null
-    val p1 = statusId?.let { priorityByCategoryId[it] }
-    val p2 = eventTypeId?.let { priorityByCategoryId[it] }
-    val p3 = orgId?.let { priorityByCategoryId[it] }
+private data class InterestPriorities(
+    val status: Map<Long, Int> = emptyMap(),
+    val eventType: Map<Long, Int> = emptyMap(),
+    val organization: Map<Long, Int> = emptyMap(),
+)
+
+private fun Event.matchedInterestPriority(priorities: InterestPriorities): Int? {
+    val p1 = statusId?.let { priorities.status[it] }
+    val p2 = eventTypeId?.let { priorities.eventType[it] }
+    val p3 = orgId?.let { priorities.organization[it] }
     return listOfNotNull(p1, p2, p3).minOrNull()
 }
 

--- a/hangsha/src/main/kotlin/com/team1/hangsha/event/service/ManualEventDraftParser.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/event/service/ManualEventDraftParser.kt
@@ -2,8 +2,7 @@ package com.team1.hangsha.event.service
 
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.team1.hangsha.category.repository.CategoryGroupRepository
-import com.team1.hangsha.category.repository.CategoryRepository
+import com.team1.hangsha.category.repository.EventTypeRepository
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -47,8 +46,7 @@ data class ManualEventDraftSession(
 @Service
 class ManualEventDraftParser(
     private val objectMapper: ObjectMapper,
-    private val categoryGroupRepository: CategoryGroupRepository,
-    private val categoryRepository: CategoryRepository,
+    private val eventTypeRepository: EventTypeRepository,
     @Value("\${elice.ml-api.event-parser.enabled:false}") private val enabled: Boolean,
     @Value("\${elice.ml-api.event-parser.url:https://mlapi.run/286e9158-d32e-436d-a23d-36b43fc8e68a/v1/chat/completions}") private val url: String,
     @Value("\${elice.ml-api.event-parser.model:gpt-5.6-luna}") private val model: String,
@@ -180,8 +178,7 @@ class ManualEventDraftParser(
 
     private fun findEventTypeId(eventType: String?): Long? {
         val typeName = eventType?.trim()?.takeIf { it in PROGRAM_TYPES } ?: return null
-        val groupId = categoryGroupRepository.findByName("프로그램 유형")?.id ?: return null
-        return categoryRepository.findByGroupIdAndName(groupId, typeName)?.id
+        return eventTypeRepository.findByName(typeName)?.id
     }
 
     companion object {

--- a/hangsha/src/main/kotlin/com/team1/hangsha/memo/repository/MemoQueryRepository.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/memo/repository/MemoQueryRepository.kt
@@ -34,7 +34,7 @@ class MemoQueryRepository(
 ) {
     /**
      * 유저의 메모를 행사 정보(마감일/주최기관/북마크 여부)와 함께 조회한다.
-     * events/categories/bookmarks는 LEFT JOIN이라 행사가 지워졌거나 주최기관 미분류여도 메모는 그대로 나온다.
+     * events/organizations/bookmarks는 LEFT JOIN이라 행사가 지워졌거나 주최기관 미분류여도 메모는 그대로 나온다.
      */
     fun findMemosWithEventByUserId(userId: Long): List<MemoWithEventRow> {
         val sql = """
@@ -51,7 +51,7 @@ class MemoQueryRepository(
                    (b.id IS NOT NULL) AS is_bookmarked
             FROM memos m
             LEFT JOIN events e ON e.id = m.event_id
-            LEFT JOIN categories c ON c.id = e.org_id
+            LEFT JOIN organizations c ON c.id = e.org_id
             LEFT JOIN bookmarks b ON b.event_id = m.event_id AND b.user_id = :userId
             WHERE m.user_id = :userId
             ORDER BY m.created_at DESC, m.id DESC

--- a/hangsha/src/main/kotlin/com/team1/hangsha/user/controller/UserPreferenceController.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/user/controller/UserPreferenceController.kt
@@ -19,6 +19,8 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestParam
+import com.team1.hangsha.user.model.InterestCategoryType
 
 
 @RestController
@@ -47,9 +49,10 @@ class UserPreferenceController (
     @DeleteMapping("/interest-categories/{categoryId}")
     fun deleteInterestCategory(
         @Parameter(hidden = true) @LoggedInUser user: User,
-        @PathVariable categoryId: Long
+        @PathVariable categoryId: Long,
+        @RequestParam categoryType: InterestCategoryType,
     ): ResponseEntity<Void> {
-        userPreferenceService.delete(user.id!!, categoryId)
+        userPreferenceService.delete(user.id!!, categoryType, categoryId)
         return ResponseEntity.noContent().build()
     }
 

--- a/hangsha/src/main/kotlin/com/team1/hangsha/user/dto/Preference/ListInterestCategoryResponse.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/user/dto/Preference/ListInterestCategoryResponse.kt
@@ -1,6 +1,6 @@
 package com.team1.hangsha.user.dto.Preference
 
-import com.team1.hangsha.category.dto.core.CategoryDto
+import com.team1.hangsha.user.model.InterestCategoryType
 import io.swagger.v3.oas.annotations.media.Schema
 
 data class ListInterestCategoryResponse(
@@ -8,7 +8,10 @@ data class ListInterestCategoryResponse(
 ) {
     @Schema(name = "InterestCategoryItem")
     data class Item(
-        val category: CategoryDto,
+        val categoryType: InterestCategoryType,
+        val categoryId: Long,
+        val name: String,
+        val sortOrder: Int,
         val priority: Int
     )
 }

--- a/hangsha/src/main/kotlin/com/team1/hangsha/user/dto/Preference/ReplaceAllInterestCategoriesRequest.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/user/dto/Preference/ReplaceAllInterestCategoriesRequest.kt
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.Valid
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotNull
+import com.team1.hangsha.user.model.InterestCategoryType
 
 data class ReplaceAllInterestCategoriesRequest(
     @field:Valid
@@ -13,6 +14,9 @@ data class ReplaceAllInterestCategoriesRequest(
     data class Item(
         @field:NotNull
         val categoryId: Long,
+
+        @field:NotNull
+        val categoryType: InterestCategoryType,
 
         @field:Min(1)
         val priority: Int

--- a/hangsha/src/main/kotlin/com/team1/hangsha/user/model/UserInterestCategory.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/user/model/UserInterestCategory.kt
@@ -5,7 +5,7 @@ import org.springframework.data.relational.core.mapping.Table
 import org.springframework.data.annotation.CreatedDate
 import java.time.Instant
 
-@Table("user_interest_categories")
+@Table("legacy_user_interest_categories")
 data class UserInterestCategory(
     @Id
     val id: Long? = null,

--- a/hangsha/src/main/kotlin/com/team1/hangsha/user/repository/UserInterestDomainRepository.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/user/repository/UserInterestDomainRepository.kt
@@ -16,16 +16,19 @@ data class InterestCategoryRow(
 class UserInterestDomainRepository(private val jdbc: NamedParameterJdbcTemplate) {
     fun findAllByUserId(userId: Long): List<InterestCategoryRow> = jdbc.query(
         """
-        SELECT 'EVENT_STATUS' AS category_type, es.id AS category_id, es.name, es.sort_order, u.priority
-        FROM user_interest_event_statuses u JOIN event_statuses es ON es.id = u.event_status_id
-        WHERE u.user_id = :userId
-        UNION ALL
-        SELECT 'EVENT_TYPE', et.id, et.name, et.sort_order, u.priority
-        FROM user_interest_event_types u JOIN event_types et ON et.id = u.event_type_id
-        WHERE u.user_id = :userId
-        UNION ALL
-        SELECT 'ORGANIZATION', o.id, o.name, o.sort_order, u.priority
-        FROM user_interest_organizations u JOIN organizations o ON o.id = u.organization_id
+        SELECT CASE
+                 WHEN u.event_status_id IS NOT NULL THEN 'EVENT_STATUS'
+                 WHEN u.event_type_id IS NOT NULL THEN 'EVENT_TYPE'
+                 ELSE 'ORGANIZATION'
+               END AS category_type,
+               COALESCE(u.event_status_id, u.event_type_id, u.organization_id) AS category_id,
+               COALESCE(es.name, et.name, o.name) AS name,
+               COALESCE(es.sort_order, et.sort_order, o.sort_order) AS sort_order,
+               u.priority
+        FROM user_interest_categories u
+        LEFT JOIN event_statuses es ON es.id = u.event_status_id
+        LEFT JOIN event_types et ON et.id = u.event_type_id
+        LEFT JOIN organizations o ON o.id = u.organization_id
         WHERE u.user_id = :userId
         ORDER BY priority ASC
         """.trimIndent(), mapOf("userId" to userId)
@@ -38,25 +41,35 @@ class UserInterestDomainRepository(private val jdbc: NamedParameterJdbcTemplate)
     }
 
     fun replaceAll(userId: Long, items: List<InterestCategoryRow>) {
-        jdbc.update("DELETE FROM user_interest_event_statuses WHERE user_id = :userId", mapOf("userId" to userId))
-        jdbc.update("DELETE FROM user_interest_event_types WHERE user_id = :userId", mapOf("userId" to userId))
-        jdbc.update("DELETE FROM user_interest_organizations WHERE user_id = :userId", mapOf("userId" to userId))
+        jdbc.update("DELETE FROM user_interest_categories WHERE user_id = :userId", mapOf("userId" to userId))
         items.forEach { item ->
             val sql = when (item.type) {
-                InterestCategoryType.EVENT_STATUS -> "INSERT INTO user_interest_event_statuses (user_id, event_status_id, priority) VALUES (:userId, :id, :priority)"
-                InterestCategoryType.EVENT_TYPE -> "INSERT INTO user_interest_event_types (user_id, event_type_id, priority) VALUES (:userId, :id, :priority)"
-                InterestCategoryType.ORGANIZATION -> "INSERT INTO user_interest_organizations (user_id, organization_id, priority) VALUES (:userId, :id, :priority)"
+                InterestCategoryType.EVENT_STATUS -> "INSERT INTO user_interest_categories (user_id, event_status_id, priority) VALUES (:userId, :id, :priority)"
+                InterestCategoryType.EVENT_TYPE -> "INSERT INTO user_interest_categories (user_id, event_type_id, priority) VALUES (:userId, :id, :priority)"
+                InterestCategoryType.ORGANIZATION -> "INSERT INTO user_interest_categories (user_id, organization_id, priority) VALUES (:userId, :id, :priority)"
             }
             jdbc.update(sql, mapOf("userId" to userId, "id" to item.categoryId, "priority" to item.priority))
         }
     }
 
-    fun delete(userId: Long, type: InterestCategoryType, categoryId: Long): Int {
-        val (table, column) = when (type) {
-            InterestCategoryType.EVENT_STATUS -> "user_interest_event_statuses" to "event_status_id"
-            InterestCategoryType.EVENT_TYPE -> "user_interest_event_types" to "event_type_id"
-            InterestCategoryType.ORGANIZATION -> "user_interest_organizations" to "organization_id"
+    fun add(userId: Long, type: InterestCategoryType, categoryId: Long, priority: Int) {
+        val column = when (type) {
+            InterestCategoryType.EVENT_STATUS -> "event_status_id"
+            InterestCategoryType.EVENT_TYPE -> "event_type_id"
+            InterestCategoryType.ORGANIZATION -> "organization_id"
         }
-        return jdbc.update("DELETE FROM $table WHERE user_id = :userId AND $column = :categoryId", mapOf("userId" to userId, "categoryId" to categoryId))
+        jdbc.update(
+            "INSERT INTO user_interest_categories (user_id, $column, priority) VALUES (:userId, :categoryId, :priority)",
+            mapOf("userId" to userId, "categoryId" to categoryId, "priority" to priority),
+        )
+    }
+
+    fun delete(userId: Long, type: InterestCategoryType, categoryId: Long): Int {
+        val column = when (type) {
+            InterestCategoryType.EVENT_STATUS -> "event_status_id"
+            InterestCategoryType.EVENT_TYPE -> "event_type_id"
+            InterestCategoryType.ORGANIZATION -> "organization_id"
+        }
+        return jdbc.update("DELETE FROM user_interest_categories WHERE user_id = :userId AND $column = :categoryId", mapOf("userId" to userId, "categoryId" to categoryId))
     }
 }

--- a/hangsha/src/main/kotlin/com/team1/hangsha/user/repository/UserInterestDomainRepository.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/user/repository/UserInterestDomainRepository.kt
@@ -1,0 +1,62 @@
+package com.team1.hangsha.user.repository
+
+import com.team1.hangsha.user.model.InterestCategoryType
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import org.springframework.stereotype.Repository
+
+data class InterestCategoryRow(
+    val type: InterestCategoryType,
+    val categoryId: Long,
+    val name: String,
+    val sortOrder: Int,
+    val priority: Int,
+)
+
+@Repository
+class UserInterestDomainRepository(private val jdbc: NamedParameterJdbcTemplate) {
+    fun findAllByUserId(userId: Long): List<InterestCategoryRow> = jdbc.query(
+        """
+        SELECT 'EVENT_STATUS' AS category_type, es.id AS category_id, es.name, es.sort_order, u.priority
+        FROM user_interest_event_statuses u JOIN event_statuses es ON es.id = u.event_status_id
+        WHERE u.user_id = :userId
+        UNION ALL
+        SELECT 'EVENT_TYPE', et.id, et.name, et.sort_order, u.priority
+        FROM user_interest_event_types u JOIN event_types et ON et.id = u.event_type_id
+        WHERE u.user_id = :userId
+        UNION ALL
+        SELECT 'ORGANIZATION', o.id, o.name, o.sort_order, u.priority
+        FROM user_interest_organizations u JOIN organizations o ON o.id = u.organization_id
+        WHERE u.user_id = :userId
+        ORDER BY priority ASC
+        """.trimIndent(), mapOf("userId" to userId)
+    ) { rs, _ ->
+        InterestCategoryRow(
+            type = InterestCategoryType.valueOf(rs.getString("category_type")),
+            categoryId = rs.getLong("category_id"), name = rs.getString("name"),
+            sortOrder = rs.getInt("sort_order"), priority = rs.getInt("priority"),
+        )
+    }
+
+    fun replaceAll(userId: Long, items: List<InterestCategoryRow>) {
+        jdbc.update("DELETE FROM user_interest_event_statuses WHERE user_id = :userId", mapOf("userId" to userId))
+        jdbc.update("DELETE FROM user_interest_event_types WHERE user_id = :userId", mapOf("userId" to userId))
+        jdbc.update("DELETE FROM user_interest_organizations WHERE user_id = :userId", mapOf("userId" to userId))
+        items.forEach { item ->
+            val sql = when (item.type) {
+                InterestCategoryType.EVENT_STATUS -> "INSERT INTO user_interest_event_statuses (user_id, event_status_id, priority) VALUES (:userId, :id, :priority)"
+                InterestCategoryType.EVENT_TYPE -> "INSERT INTO user_interest_event_types (user_id, event_type_id, priority) VALUES (:userId, :id, :priority)"
+                InterestCategoryType.ORGANIZATION -> "INSERT INTO user_interest_organizations (user_id, organization_id, priority) VALUES (:userId, :id, :priority)"
+            }
+            jdbc.update(sql, mapOf("userId" to userId, "id" to item.categoryId, "priority" to item.priority))
+        }
+    }
+
+    fun delete(userId: Long, type: InterestCategoryType, categoryId: Long): Int {
+        val (table, column) = when (type) {
+            InterestCategoryType.EVENT_STATUS -> "user_interest_event_statuses" to "event_status_id"
+            InterestCategoryType.EVENT_TYPE -> "user_interest_event_types" to "event_type_id"
+            InterestCategoryType.ORGANIZATION -> "user_interest_organizations" to "organization_id"
+        }
+        return jdbc.update("DELETE FROM $table WHERE user_id = :userId AND $column = :categoryId", mapOf("userId" to userId, "categoryId" to categoryId))
+    }
+}

--- a/hangsha/src/main/kotlin/com/team1/hangsha/user/service/UserPreferenceService.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/user/service/UserPreferenceService.kt
@@ -2,23 +2,27 @@ package com.team1.hangsha.user.service
 
 import com.team1.hangsha.common.error.DomainException
 import com.team1.hangsha.common.error.ErrorCode
-import com.team1.hangsha.category.dto.core.CategoryDto
-import com.team1.hangsha.category.repository.CategoryRepository
+import com.team1.hangsha.category.repository.EventTypeRepository
+import com.team1.hangsha.category.repository.OrganizationRepository
+import com.team1.hangsha.category.repository.EventStatusRepository
 import com.team1.hangsha.user.dto.Preference.ListExcludedKeywordResponse
 import com.team1.hangsha.user.dto.Preference.ListInterestCategoryResponse
 import com.team1.hangsha.user.dto.Preference.ReplaceAllInterestCategoriesRequest
 import com.team1.hangsha.user.model.UserExcludedKeyword
 import com.team1.hangsha.user.repository.UserExcludedKeywordRepository
-import com.team1.hangsha.user.repository.UserInterestCategoryRepository
+import com.team1.hangsha.user.repository.InterestCategoryRow
+import com.team1.hangsha.user.repository.UserInterestDomainRepository
 import org.springframework.dao.DuplicateKeyException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 @Service
 class UserPreferenceService(
-    private val userInterestCategoryRepository: UserInterestCategoryRepository,
+    private val userInterestDomainRepository: UserInterestDomainRepository,
     private val userExcludedKeywordRepository: UserExcludedKeywordRepository,
-    private val categoryRepository: CategoryRepository,
+    private val eventStatusRepository: EventStatusRepository,
+    private val eventTypeRepository: EventTypeRepository,
+    private val organizationRepository: OrganizationRepository,
 ) {
 
     // ==============================
@@ -26,16 +30,14 @@ class UserPreferenceService(
     // ==============================
     @Transactional(readOnly = true)
     fun listInterestCategory(userId: Long): List<ListInterestCategoryResponse.Item> {
-        val rows = userInterestCategoryRepository.findAllWithCategoryByUserId(userId)
+        val rows = userInterestDomainRepository.findAllByUserId(userId)
 
         return rows.map { row ->
             ListInterestCategoryResponse.Item(
-                category = CategoryDto(
-                    id = row.categoryId,
-                    groupId = row.groupId,
-                    name = row.name,
-                    sortOrder = row.sortOrder,
-                ),
+                categoryType = row.type,
+                categoryId = row.categoryId,
+                name = row.name,
+                sortOrder = row.sortOrder,
                 priority = row.priority
             )
         }
@@ -46,8 +48,8 @@ class UserPreferenceService(
         val items = req.items
 
         // 1) categoryId 중복 금지
-        val categoryIds = items.map { it.categoryId }
-        if (categoryIds.size != categoryIds.distinct().size) {
+        val categoryKeys = items.map { it.categoryType to it.categoryId }
+        if (categoryKeys.size != categoryKeys.distinct().size) {
             throw DomainException(ErrorCode.INVALID_REQUEST)
         }
 
@@ -68,31 +70,25 @@ class UserPreferenceService(
 
         // 4) category 존재 검증 (IN 한번)
         if (items.isNotEmpty()) {
-            val existCount = categoryRepository.countByIds(categoryIds)
-            if (existCount != categoryIds.size) {
+            val allExist = items.all { item -> when (item.categoryType) {
+                com.team1.hangsha.user.model.InterestCategoryType.EVENT_STATUS -> eventStatusRepository.existsById(item.categoryId)
+                com.team1.hangsha.user.model.InterestCategoryType.EVENT_TYPE -> eventTypeRepository.existsById(item.categoryId)
+                com.team1.hangsha.user.model.InterestCategoryType.ORGANIZATION -> organizationRepository.existsById(item.categoryId)
+            } }
+            if (!allExist) {
                 throw DomainException(ErrorCode.INVALID_REQUEST)
             }
         }
 
         // 5) 전체 교체 (트랜잭션)
-        userInterestCategoryRepository.deleteAllByUserId(userId)
-
-        if (items.isNotEmpty()) {
-            userInterestCategoryRepository.saveAll(
-                items.map {
-                    com.team1.hangsha.user.model.UserInterestCategory(
-                        userId = userId,
-                        categoryId = it.categoryId,
-                        priority = it.priority
-                    )
-                }
-            )
-        }
+        userInterestDomainRepository.replaceAll(userId, items.map {
+            InterestCategoryRow(it.categoryType, it.categoryId, "", 0, it.priority)
+        })
     }
 
     @Transactional
-    fun delete(userId: Long, categoryId: Long) {
-        val affected = userInterestCategoryRepository.deleteByUserIdAndCategoryId(userId, categoryId)
+    fun delete(userId: Long, categoryType: com.team1.hangsha.user.model.InterestCategoryType, categoryId: Long) {
+        val affected = userInterestDomainRepository.delete(userId, categoryType, categoryId)
         if (affected == 0) {
             throw DomainException(ErrorCode.INVALID_REQUEST)
         }

--- a/hangsha/src/main/resources/db/migration/V32__split_categories_into_domain_tables.sql
+++ b/hangsha/src/main/resources/db/migration/V32__split_categories_into_domain_tables.sql
@@ -44,63 +44,49 @@ FROM categories c
 JOIN category_groups cg ON cg.id = c.group_id
 WHERE cg.name = '주체기관';
 
--- Each domain gets its own interest relation, so every column has a real FK.
-CREATE TABLE user_interest_event_statuses (
+-- Keep one interest list and enforce that each row references exactly one domain.
+RENAME TABLE user_interest_categories TO legacy_user_interest_categories;
+
+CREATE TABLE user_interest_categories (
     id BIGINT NOT NULL AUTO_INCREMENT,
     user_id BIGINT NOT NULL,
-    event_status_id BIGINT NOT NULL,
+    event_status_id BIGINT NULL,
+    event_type_id BIGINT NULL,
+    organization_id BIGINT NULL,
     priority INT NOT NULL,
     created_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
     PRIMARY KEY (id),
-    UNIQUE KEY uk_uies_user_status (user_id, event_status_id),
-    KEY idx_uies_user_priority (user_id, priority),
-    CONSTRAINT fk_uies_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE ON UPDATE CASCADE,
-    CONSTRAINT fk_uies_status FOREIGN KEY (event_status_id) REFERENCES event_statuses(id) ON DELETE RESTRICT ON UPDATE CASCADE
+    UNIQUE KEY uk_uic_user_event_status (user_id, event_status_id),
+    UNIQUE KEY uk_uic_user_event_type (user_id, event_type_id),
+    UNIQUE KEY uk_uic_user_organization (user_id, organization_id),
+    UNIQUE KEY uk_uic_user_priority (user_id, priority),
+    KEY idx_uic_user_priority (user_id, priority),
+    CONSTRAINT chk_uic_exactly_one_domain CHECK (
+        (event_status_id IS NOT NULL) + (event_type_id IS NOT NULL) + (organization_id IS NOT NULL) = 1
+    ),
+    CONSTRAINT fk_uic_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT fk_uic_event_status FOREIGN KEY (event_status_id) REFERENCES event_statuses(id) ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT fk_uic_event_type FOREIGN KEY (event_type_id) REFERENCES event_types(id) ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT fk_uic_organization FOREIGN KEY (organization_id) REFERENCES organizations(id) ON DELETE RESTRICT ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
-CREATE TABLE user_interest_event_types (
-    id BIGINT NOT NULL AUTO_INCREMENT,
-    user_id BIGINT NOT NULL,
-    event_type_id BIGINT NOT NULL,
-    priority INT NOT NULL,
-    created_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
-    PRIMARY KEY (id),
-    UNIQUE KEY uk_uiet_user_type (user_id, event_type_id),
-    KEY idx_uiet_user_priority (user_id, priority),
-    CONSTRAINT fk_uiet_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE ON UPDATE CASCADE,
-    CONSTRAINT fk_uiet_type FOREIGN KEY (event_type_id) REFERENCES event_types(id) ON DELETE RESTRICT ON UPDATE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
-
-CREATE TABLE user_interest_organizations (
-    id BIGINT NOT NULL AUTO_INCREMENT,
-    user_id BIGINT NOT NULL,
-    organization_id BIGINT NOT NULL,
-    priority INT NOT NULL,
-    created_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
-    PRIMARY KEY (id),
-    UNIQUE KEY uk_uio_user_organization (user_id, organization_id),
-    KEY idx_uio_user_priority (user_id, priority),
-    CONSTRAINT fk_uio_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE ON UPDATE CASCADE,
-    CONSTRAINT fk_uio_organization FOREIGN KEY (organization_id) REFERENCES organizations(id) ON DELETE RESTRICT ON UPDATE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
-
-INSERT INTO user_interest_event_statuses (user_id, event_status_id, priority, created_at)
+INSERT INTO user_interest_categories (user_id, event_status_id, priority, created_at)
 SELECT uic.user_id, es.id, uic.priority, uic.created_at
-FROM user_interest_categories uic
+FROM legacy_user_interest_categories uic
 JOIN categories c ON c.id = uic.category_id
 JOIN category_groups cg ON cg.id = c.group_id AND cg.name = '모집현황'
 JOIN event_statuses es ON es.name = c.name;
 
-INSERT INTO user_interest_event_types (user_id, event_type_id, priority, created_at)
+INSERT INTO user_interest_categories (user_id, event_type_id, priority, created_at)
 SELECT uic.user_id, et.id, uic.priority, uic.created_at
-FROM user_interest_categories uic
+FROM legacy_user_interest_categories uic
 JOIN categories c ON c.id = uic.category_id
 JOIN category_groups cg ON cg.id = c.group_id AND cg.name = '프로그램 유형'
 JOIN event_types et ON et.name = c.name;
 
-INSERT INTO user_interest_organizations (user_id, organization_id, priority, created_at)
+INSERT INTO user_interest_categories (user_id, organization_id, priority, created_at)
 SELECT uic.user_id, o.id, uic.priority, uic.created_at
-FROM user_interest_categories uic
+FROM legacy_user_interest_categories uic
 JOIN categories c ON c.id = uic.category_id
 JOIN category_groups cg ON cg.id = c.group_id AND cg.name = '주체기관'
 JOIN organizations o ON o.name = c.name;

--- a/hangsha/src/main/resources/db/migration/V32__split_categories_into_domain_tables.sql
+++ b/hangsha/src/main/resources/db/migration/V32__split_categories_into_domain_tables.sql
@@ -1,0 +1,134 @@
+-- Categories have three unrelated domains.  Keep the old tables for one
+-- release so a rollback remains possible, but move every live reference to
+-- the domain table that owns it.
+CREATE TABLE event_statuses (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    name VARCHAR(100) NOT NULL,
+    sort_order INT NOT NULL DEFAULT 0,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_event_statuses_name (name)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE event_types (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    name VARCHAR(100) NOT NULL,
+    sort_order INT NOT NULL DEFAULT 0,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_event_types_name (name)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE organizations (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    name VARCHAR(100) NOT NULL,
+    sort_order INT NOT NULL DEFAULT 0,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_organizations_name (name)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+INSERT INTO event_statuses (name, sort_order)
+SELECT c.name, c.sort_order
+FROM categories c
+JOIN category_groups cg ON cg.id = c.group_id
+WHERE cg.name = '모집현황';
+
+INSERT INTO event_types (name, sort_order)
+SELECT c.name, c.sort_order
+FROM categories c
+JOIN category_groups cg ON cg.id = c.group_id
+WHERE cg.name = '프로그램 유형';
+
+INSERT INTO organizations (name, sort_order, created_at)
+SELECT c.name, c.sort_order, c.created_at
+FROM categories c
+JOIN category_groups cg ON cg.id = c.group_id
+WHERE cg.name = '주체기관';
+
+-- Each domain gets its own interest relation, so every column has a real FK.
+CREATE TABLE user_interest_event_statuses (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    user_id BIGINT NOT NULL,
+    event_status_id BIGINT NOT NULL,
+    priority INT NOT NULL,
+    created_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_uies_user_status (user_id, event_status_id),
+    KEY idx_uies_user_priority (user_id, priority),
+    CONSTRAINT fk_uies_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT fk_uies_status FOREIGN KEY (event_status_id) REFERENCES event_statuses(id) ON DELETE RESTRICT ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE user_interest_event_types (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    user_id BIGINT NOT NULL,
+    event_type_id BIGINT NOT NULL,
+    priority INT NOT NULL,
+    created_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_uiet_user_type (user_id, event_type_id),
+    KEY idx_uiet_user_priority (user_id, priority),
+    CONSTRAINT fk_uiet_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT fk_uiet_type FOREIGN KEY (event_type_id) REFERENCES event_types(id) ON DELETE RESTRICT ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE user_interest_organizations (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    user_id BIGINT NOT NULL,
+    organization_id BIGINT NOT NULL,
+    priority INT NOT NULL,
+    created_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_uio_user_organization (user_id, organization_id),
+    KEY idx_uio_user_priority (user_id, priority),
+    CONSTRAINT fk_uio_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT fk_uio_organization FOREIGN KEY (organization_id) REFERENCES organizations(id) ON DELETE RESTRICT ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+INSERT INTO user_interest_event_statuses (user_id, event_status_id, priority, created_at)
+SELECT uic.user_id, es.id, uic.priority, uic.created_at
+FROM user_interest_categories uic
+JOIN categories c ON c.id = uic.category_id
+JOIN category_groups cg ON cg.id = c.group_id AND cg.name = '모집현황'
+JOIN event_statuses es ON es.name = c.name;
+
+INSERT INTO user_interest_event_types (user_id, event_type_id, priority, created_at)
+SELECT uic.user_id, et.id, uic.priority, uic.created_at
+FROM user_interest_categories uic
+JOIN categories c ON c.id = uic.category_id
+JOIN category_groups cg ON cg.id = c.group_id AND cg.name = '프로그램 유형'
+JOIN event_types et ON et.name = c.name;
+
+INSERT INTO user_interest_organizations (user_id, organization_id, priority, created_at)
+SELECT uic.user_id, o.id, uic.priority, uic.created_at
+FROM user_interest_categories uic
+JOIN categories c ON c.id = uic.category_id
+JOIN category_groups cg ON cg.id = c.group_id AND cg.name = '주체기관'
+JOIN organizations o ON o.name = c.name;
+
+ALTER TABLE events
+    DROP FOREIGN KEY fk_events_status,
+    DROP FOREIGN KEY fk_events_event_type,
+    DROP FOREIGN KEY fk_events_org;
+
+UPDATE events e
+JOIN categories c ON c.id = e.status_id
+JOIN category_groups cg ON cg.id = c.group_id AND cg.name = '모집현황'
+JOIN event_statuses es ON es.name = c.name
+SET e.status_id = es.id;
+
+UPDATE events e
+JOIN categories c ON c.id = e.event_type_id
+JOIN category_groups cg ON cg.id = c.group_id AND cg.name = '프로그램 유형'
+JOIN event_types et ON et.name = c.name
+SET e.event_type_id = et.id;
+
+UPDATE events e
+JOIN categories c ON c.id = e.org_id
+JOIN category_groups cg ON cg.id = c.group_id AND cg.name = '주체기관'
+JOIN organizations o ON o.name = c.name
+SET e.org_id = o.id;
+
+ALTER TABLE events
+    ADD CONSTRAINT fk_events_status FOREIGN KEY (status_id) REFERENCES event_statuses(id),
+    ADD CONSTRAINT fk_events_event_type FOREIGN KEY (event_type_id) REFERENCES event_types(id),
+    ADD CONSTRAINT fk_events_org FOREIGN KEY (org_id) REFERENCES organizations(id);

--- a/hangsha/src/main/resources/static/openapi.yaml
+++ b/hangsha/src/main/resources/static/openapi.yaml
@@ -195,7 +195,7 @@ components:
         요청 바디는 username/profileImageUrl 중 하나 이상을 포함해야 함.
 
     # ---------------- Categories ----------------
-    CategoryGroupDto:
+    CategoryItemDto:
       type: object
       required: [id, name, sortOrder]
       properties:
@@ -203,39 +203,13 @@ components:
         name: { type: string }
         sortOrder: { type: integer, description: "UI에서 고정 순서로 보여주기 위한 정렬값" }
 
-    CategoryDto:
-      type: object
-      required: [id, groupId, name, sortOrder]
-      properties:
-        id: { type: integer, format: int64 }
-        groupId: { type: integer, format: int64 }
-        name: { type: string }
-        sortOrder: { type: integer, description: "UI에서 고정 순서로 보여주기 위한 정렬값" }
-
-    CategoryResponse:
-      type: object
-      required: [group, categories]
-      properties:
-        group: { $ref: '#/components/schemas/CategoryGroupDto' }
-        categories:
-          type: array
-          items: { $ref: '#/components/schemas/CategoryDto' }
-
-    ListCategoryGroupWithCategoriesResponse:
+    ListCategoryItemsResponse:
       type: object
       required: [ items ]
       properties:
         items:
           type: array
-          items: { $ref: '#/components/schemas/CategoryResponse' }
-
-    ListOrgCategoriesResponse:
-      type: object
-      required: [ items ]
-      properties:
-        items:
-          type: array
-          items: { $ref: '#/components/schemas/CategoryDto' }
+          items: { $ref: '#/components/schemas/CategoryItemDto' }
 
 
     # ---------------- Preference ----------------
@@ -269,8 +243,9 @@ components:
           description: "유저의 관심 카테고리 전체 목록을 이 배열로 교체합니다."
           items:
             type: object
-            required: [ categoryId, priority ]
+            required: [ categoryType, categoryId, priority ]
             properties:
+              categoryType: { type: string, enum: [EVENT_STATUS, EVENT_TYPE, ORGANIZATION] }
               categoryId: { type: integer, format: int64 }
               priority:
                 type: integer
@@ -296,9 +271,12 @@ components:
           type: array
           items:
             type: object
-            required: [category, priority]
+            required: [categoryType, categoryId, name, sortOrder, priority]
             properties:
-              category: { $ref: '#/components/schemas/CategoryDto' }
+              categoryType: { type: string, enum: [EVENT_STATUS, EVENT_TYPE, ORGANIZATION] }
+              categoryId: { type: integer, format: int64 }
+              name: { type: string }
+              sortOrder: { type: integer }
               priority:
                 type: integer
                 minimum: 1
@@ -1076,31 +1054,38 @@ paths:
               schema: { $ref: '#/components/schemas/ErrorResponse' }
 
   # ---------------- Categories ----------------
-  /category-groups/with-categories:
+  /event-statuses:
     get:
       tags: [Categories]
-      summary: 카테고리 그룹 + 카테고리 목록
+      summary: 모집 현황 목록 조회
       responses:
         "200":
           description: OK
           content:
             application/json:
-              schema: { $ref: '#/components/schemas/ListCategoryGroupWithCategoriesResponse' }
+              schema: { $ref: '#/components/schemas/ListCategoryItemsResponse' }
 
-  /categories/orgs:
+  /event-types:
     get:
       tags: [Categories]
-      summary: 주체기관 카테고리 목록 조회
-      description: |
-        필터 UI(주체기관 드롭다운)에서 사용할 주체기관 목록을 반환합니다.
-        - 내부적으로 "주체기관" category_group에 속한 categories를 조회합니다.
-        - 반환된 items[].id 값을 이벤트 조회 API의 orgId 필터로 그대로 사용합니다.
+      summary: 프로그램 유형 목록 조회
       responses:
         "200":
           description: OK
           content:
             application/json:
-              schema: { $ref: '#/components/schemas/ListOrgCategoriesResponse' }
+              schema: { $ref: '#/components/schemas/ListCategoryItemsResponse' }
+
+  /organizations:
+    get:
+      tags: [Categories]
+      summary: 주체기관 목록 조회
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ListCategoryItemsResponse' }
 
   # ---------------- Preference ----------------
   /users/me/excluded-keywords:
@@ -1169,6 +1154,10 @@ paths:
           name: categoryId
           required: true
           schema: { type: integer, format: int64 }
+        - in: query
+          name: categoryType
+          required: true
+          schema: { type: string, enum: [EVENT_STATUS, EVENT_TYPE, ORGANIZATION] }
       responses:
         "204": { description: No Content }
 

--- a/hangsha/src/test/kotlin/com/team1/hangsha/CategoryIntegrationTest.kt
+++ b/hangsha/src/test/kotlin/com/team1/hangsha/CategoryIntegrationTest.kt
@@ -7,108 +7,33 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
 
 class CategoryIntegrationTest : IntegrationTestBase() {
+    @Test
+    fun `event status와 event type 목록은 공개 API로 조회한다`() {
+        mockMvc.perform(get("/api/v1/event-statuses"))
+            .andExpect(status().isOk)
+            .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.items[0].id").isNumber)
+            .andExpect(jsonPath("$.items[0].name").isString)
+            .andExpect(jsonPath("$.items[0].sortOrder").isNumber)
+
+        mockMvc.perform(get("/api/v1/event-types"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.items[0].id").isNumber)
+    }
 
     @Test
-    fun `GET category-groups with-categories - 그룹 sortOrder 오름차순, 각 그룹의 categories도 sortOrder 오름차순`() {
-        val g2 = dataGenerator.generateCategoryGroup(name = "g2", sortOrder = 20)
-        val g1 = dataGenerator.generateCategoryGroup(name = "g1", sortOrder = 10)
+    fun `organizations는 두 번 이상 사용된 기관만 반환한다`() {
+        val first = dataGenerator.generateOrgCategory(name = "기관-1")
+        val second = dataGenerator.generateOrgCategory(name = "기관-2")
+        val once = dataGenerator.generateOrgCategory(name = "기관-3")
+        repeat(2) { dataGenerator.generateEvent(orgId = first.id) }
+        repeat(2) { dataGenerator.generateEvent(orgId = second.id) }
+        dataGenerator.generateEvent(orgId = once.id)
 
-        val c12 = dataGenerator.generateCategory(group = g1, name = "c12", sortOrder = 2)
-        val c11 = dataGenerator.generateCategory(group = g1, name = "c11", sortOrder = 1)
-
-        val c21 = dataGenerator.generateCategory(group = g2, name = "c21", sortOrder = 1)
-
-        mockMvc.perform(
-            get("/api/v1/category-groups/with-categories")
-        )
+        mockMvc.perform(get("/api/v1/organizations"))
             .andExpect(status().isOk)
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-            .andExpect(jsonPath("$.items").isArray)
             .andExpect(jsonPath("$.items.length()").value(2))
-
-            // 그룹 sortOrder 오름차순: g1(10) -> g2(20)
-            .andExpect(jsonPath("$.items[0].group.id").value(g1.id!!))
-            .andExpect(jsonPath("$.items[0].group.name").value("g1"))
-            .andExpect(jsonPath("$.items[0].group.sortOrder").value(10))
-
-            .andExpect(jsonPath("$.items[1].group.id").value(g2.id!!))
-            .andExpect(jsonPath("$.items[1].group.name").value("g2"))
-            .andExpect(jsonPath("$.items[1].group.sortOrder").value(20))
-
-            // g1의 categories도 sortOrder 오름차순: c11(1) -> c12(2)
-            .andExpect(jsonPath("$.items[0].categories.length()").value(2))
-            .andExpect(jsonPath("$.items[0].categories[0].id").value(c11.id!!))
-            .andExpect(jsonPath("$.items[0].categories[0].groupId").value(g1.id!!))
-            .andExpect(jsonPath("$.items[0].categories[0].name").value("c11"))
-            .andExpect(jsonPath("$.items[0].categories[0].sortOrder").value(1))
-
-            .andExpect(jsonPath("$.items[0].categories[1].id").value(c12.id!!))
-            .andExpect(jsonPath("$.items[0].categories[1].groupId").value(g1.id!!))
-            .andExpect(jsonPath("$.items[0].categories[1].name").value("c12"))
-            .andExpect(jsonPath("$.items[0].categories[1].sortOrder").value(2))
-
-            // g2 categories
-            .andExpect(jsonPath("$.items[1].categories.length()").value(1))
-            .andExpect(jsonPath("$.items[1].categories[0].id").value(c21.id!!))
-            .andExpect(jsonPath("$.items[1].categories[0].groupId").value(g2.id!!))
-            .andExpect(jsonPath("$.items[1].categories[0].name").value("c21"))
-            .andExpect(jsonPath("$.items[1].categories[0].sortOrder").value(1))
-    }
-
-    @Test
-    fun `GET categories orgs - 두 번 이상 사용된 주체기관만 sortOrder 오름차순으로 반환`() {
-        val orgGroup = dataGenerator.generateCategoryGroup(name = "주체기관", sortOrder = 1)
-        val c1 = dataGenerator.generateCategory(group = orgGroup, name = "기관-1", sortOrder = 1)
-        val c2 = dataGenerator.generateCategory(group = orgGroup, name = "기관-2", sortOrder = 2)
-        val c3 = dataGenerator.generateCategory(group = orgGroup, name = "기관-3", sortOrder = 3)
-        dataGenerator.generateEvent(orgId = c1.id)
-        dataGenerator.generateEvent(orgId = c1.id)
-        dataGenerator.generateEvent(orgId = c2.id)
-        dataGenerator.generateEvent(orgId = c2.id)
-        dataGenerator.generateEvent(orgId = c3.id)
-
-        // 다른 그룹/카테고리 섞어도 응답엔 나오면 안 됨
-        val otherGroup = dataGenerator.generateCategoryGroup(name = "기타", sortOrder = 2)
-        dataGenerator.generateCategory(group = otherGroup, name = "기타-1", sortOrder = 1)
-
-        mockMvc.perform(
-            get("/api/v1/categories/orgs")
-        )
-            .andExpect(status().isOk)
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-            .andExpect(jsonPath("$.items").isArray)
-            .andExpect(jsonPath("$.items.length()").value(2))
-
-            // 두 번 사용된 기관만 sortOrder 순서로 반환
-            .andExpect(jsonPath("$.items[0].id").value(c1.id!!))
-            .andExpect(jsonPath("$.items[0].groupId").value(orgGroup.id!!))
-            .andExpect(jsonPath("$.items[0].name").value("기관-1"))
-            .andExpect(jsonPath("$.items[0].sortOrder").value(1))
-
-            .andExpect(jsonPath("$.items[1].id").value(c2.id!!))
-            .andExpect(jsonPath("$.items[1].groupId").value(orgGroup.id!!))
-            .andExpect(jsonPath("$.items[1].name").value("기관-2"))
-            .andExpect(jsonPath("$.items[1].sortOrder").value(2))
-    }
-
-    @Test
-    fun `GET categories orgs - 주체기관 그룹이 없으면 404`() {
-        // 아무것도 안 만들면 "주체기관" 없음 -> 404 기대
-        mockMvc.perform(
-            get("/api/v1/categories/orgs")
-        )
-            .andExpect(status().isNotFound)
-    }
-
-    @Test
-    fun `Category API - 인증 없이도 접근 가능`() {
-        dataGenerator.generateCategoryGroup(name = "g1", sortOrder = 1)
-
-        mockMvc.perform(get("/api/v1/category-groups/with-categories"))
-            .andExpect(status().isOk)
-
-        // org는 데이터가 없으면 404가 맞고, 401이 아니어야 함
-        mockMvc.perform(get("/api/v1/categories/orgs"))
-            .andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.items[0].id").value(first.id!!))
+            .andExpect(jsonPath("$.items[1].id").value(second.id!!))
     }
 }

--- a/hangsha/src/test/kotlin/com/team1/hangsha/UserPreferenceIntegrationTest.kt
+++ b/hangsha/src/test/kotlin/com/team1/hangsha/UserPreferenceIntegrationTest.kt
@@ -1,453 +1,78 @@
 package com.team1.hangsha
 
 import com.team1.hangsha.helper.IntegrationTestBase
-import com.team1.hangsha.user.repository.UserExcludedKeywordRepository
-import com.team1.hangsha.user.repository.UserInterestCategoryRepository
+import com.team1.hangsha.user.model.InterestCategoryType
+import com.team1.hangsha.user.repository.UserInterestDomainRepository
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
-import org.springframework.beans.factory.annotation.Autowired
-import com.fasterxml.jackson.core.type.TypeReference
 
 class UserPreferenceIntegrationTest : IntegrationTestBase() {
+    @Autowired lateinit var userInterestDomainRepository: UserInterestDomainRepository
 
-    @Autowired lateinit var userInterestCategoryRepository: UserInterestCategoryRepository
-    @Autowired lateinit var userExcludedKeywordRepository: UserExcludedKeywordRepository
-
-    private fun replaceAllBody(vararg pairs: Pair<Long, Int>): String {
-        val body = mapOf(
-            "items" to pairs.map { (categoryId, priority) ->
-                mapOf("categoryId" to categoryId, "priority" to priority)
-            }
-        )
-        return toJson(body)
-    }
-
-    data class ListExcludedKeywordResponse(
-        val items: List<Item>
-    ) {
-        data class Item(
-            val id: Long,
-            val keyword: String,
-            val createdAt: String,
-        )
-    }
-
-    private fun list(token: String): ListExcludedKeywordResponse {
-        val res = mockMvc.perform(
-            get("/api/v1/users/me/excluded-keywords")
-                .header("Authorization", bearer(token))
-        )
-            .andExpect(status().isOk)
-            .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-            .andReturn()
-
-        return objectMapper.readValue(
-            res.response.contentAsString,
-            object : TypeReference<ListExcludedKeywordResponse>() {}
-        )
-    }
-
-    // -----------------------------
-    // Interest Categories
-    // -----------------------------
+    private fun replaceAllBody(vararg items: Triple<InterestCategoryType, Long, Int>) = toJson(
+        mapOf("items" to items.map { (type, id, priority) ->
+            mapOf("categoryType" to type.name, "categoryId" to id, "priority" to priority)
+        }),
+    )
 
     @Test
-    fun `PUT interest categories 전체 교체하면 DB도 교체되고 GET은 priority 순으로 내려준다`() {
+    fun `interest categories는 하나의 전역 우선순위 목록으로 교체된다`() {
         val (user, token) = dataGenerator.generateUserWithAccessToken()
-        val userId = requireNotNull(user.id)
+        val first = dataGenerator.generateOrgCategory("기관-1")
+        val second = dataGenerator.generateOrgCategory("기관-2")
 
-        val group = dataGenerator.generateCategoryGroup(name = "group", sortOrder = 1)
-        val c1 = dataGenerator.generateCategory(group = group, name = "c1", sortOrder = 1)
-        val c2 = dataGenerator.generateCategory(group = group, name = "c2", sortOrder = 2)
-        val c3 = dataGenerator.generateCategory(group = group, name = "c3", sortOrder = 3)
-        val c4 = dataGenerator.generateCategory(group = group, name = "c4", sortOrder = 4)
-
-        val id1 = c1.id!!
-        val id2 = c2.id!!
-        val id3 = c3.id!!
-        val id4 = c4.id!!
-
-        // PUT: 전체 교체
-        mockMvc.perform(
-            put("/api/v1/users/me/interest-categories")
-                .header("Authorization", bearer(token))
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(
-                    replaceAllBody(
-                        id3 to 1,
-                        id1 to 2,
-                        id4 to 3,
-                        id2 to 4,
-                    )
-                )
-        )
+        mockMvc.perform(put("/api/v1/users/me/interest-categories")
+            .header("Authorization", bearer(token)).contentType(MediaType.APPLICATION_JSON)
+            .content(replaceAllBody(
+                Triple(InterestCategoryType.ORGANIZATION, second.id!!, 1),
+                Triple(InterestCategoryType.ORGANIZATION, first.id!!, 2),
+            )))
             .andExpect(status().isNoContent)
 
-        val dbRows = userInterestCategoryRepository.findAllWithCategoryByUserId(userId)
-        assertEquals(4, dbRows.size)
-        assertEquals(listOf(1, 2, 3, 4), dbRows.map { it.priority })
-        assertEquals(listOf(id3, id1, id4, id2), dbRows.map { it.categoryId })
+        val rows = userInterestDomainRepository.findAllByUserId(user.id!!)
+        assertEquals(listOf(1, 2), rows.map { it.priority })
+        assertEquals(listOf(second.id, first.id), rows.map { it.categoryId })
 
-        // GET: priority 정렬/DTO 포함 확인
-        val getResult = mockMvc.perform(
-            get("/api/v1/users/me/interest-categories")
-                .header("Authorization", bearer(token))
-        )
+        mockMvc.perform(get("/api/v1/users/me/interest-categories").header("Authorization", bearer(token)))
             .andExpect(status().isOk)
-            .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-            .andExpect(jsonPath("$.items").isArray)
-            .andExpect(jsonPath("$.items.length()").value(4))
-            .andExpect(jsonPath("$.items[0].priority").value(1))
-            .andExpect(jsonPath("$.items[1].priority").value(2))
-            .andExpect(jsonPath("$.items[2].priority").value(3))
-            .andExpect(jsonPath("$.items[3].priority").value(4))
-            .andExpect(jsonPath("$.items[0].category.id").isNumber)
-            .andExpect(jsonPath("$.items[0].category.groupId").isNumber)
-            .andExpect(jsonPath("$.items[0].category.name").isString)
-            .andExpect(jsonPath("$.items[0].category.sortOrder").isNumber)
-            .andReturn()
-
-        val root = objectMapper.readTree(getResult.response.contentAsString)
-        val priorities = root["items"].map { it["priority"].asInt() }
-        assertEquals(listOf(1, 2, 3, 4), priorities)
-
-        val firstCategoryId = root["items"][0]["category"]["id"].asLong()
-        assertEquals(id3, firstCategoryId)
+            .andExpect(jsonPath("$.items[0].categoryType").value("ORGANIZATION"))
+            .andExpect(jsonPath("$.items[0].categoryId").value(second.id!!))
     }
 
     @Test
-    fun `DELETE interest categories 한 개 삭제하면 DB에서도 삭제되고 GET 결과에서도 사라진다`() {
+    fun `같은 도메인과 id를 중복 등록하면 거부한다`() {
+        val (_, token) = dataGenerator.generateUserWithAccessToken()
+        val org = dataGenerator.generateOrgCategory()
+        mockMvc.perform(put("/api/v1/users/me/interest-categories")
+            .header("Authorization", bearer(token)).contentType(MediaType.APPLICATION_JSON)
+            .content(replaceAllBody(
+                Triple(InterestCategoryType.ORGANIZATION, org.id!!, 1),
+                Triple(InterestCategoryType.ORGANIZATION, org.id!!, 2),
+            )))
+            .andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `interest category 삭제에는 도메인 타입이 필요하다`() {
         val (user, token) = dataGenerator.generateUserWithAccessToken()
-        val userId = requireNotNull(user.id)
+        val org = dataGenerator.generateOrgCategory()
+        userInterestDomainRepository.add(user.id!!, InterestCategoryType.ORGANIZATION, org.id!!, 1)
 
-        val group = dataGenerator.generateCategoryGroup(name = "group", sortOrder = 1)
-        val c1 = dataGenerator.generateCategory(group = group, name = "c1", sortOrder = 1)
-        val c2 = dataGenerator.generateCategory(group = group, name = "c2", sortOrder = 2)
-
-        val id1 = c1.id!!
-        val id2 = c2.id!!
-
-        // 먼저 2개 저장
-        mockMvc.perform(
-            put("/api/v1/users/me/interest-categories")
-                .header("Authorization", bearer(token))
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(replaceAllBody(id1 to 1, id2 to 2))
-        )
+        mockMvc.perform(delete("/api/v1/users/me/interest-categories/${org.id}")
+            .queryParam("categoryType", "ORGANIZATION").header("Authorization", bearer(token)))
             .andExpect(status().isNoContent)
-
-        // DB 검증: 2개 존재
-        run {
-            val rows = userInterestCategoryRepository.findAllWithCategoryByUserId(userId)
-            assertEquals(2, rows.size)
-            assertEquals(setOf(id1, id2), rows.map { it.categoryId }.toSet())
-        }
-
-        // id1 삭제
-        mockMvc.perform(
-            delete("/api/v1/users/me/interest-categories/$id1")
-                .header("Authorization", bearer(token))
-        )
-            .andExpect(status().isNoContent)
-
-        val afterRows = userInterestCategoryRepository.findAllWithCategoryByUserId(userId)
-        assertEquals(1, afterRows.size)
-        assertEquals(id2, afterRows.single().categoryId)
-
-        // GET 결과는 id2만 남아야 함
-        mockMvc.perform(
-            get("/api/v1/users/me/interest-categories")
-                .header("Authorization", bearer(token))
-        )
-            .andExpect(status().isOk)
-            .andExpect(jsonPath("$.items.length()").value(1))
-            .andExpect(jsonPath("$.items[0].category.id").value(id2))
+        assertTrue(userInterestDomainRepository.findAllByUserId(user.id!!).isEmpty())
     }
 
     @Test
-    fun `PUT interest categories categoryId 중복이면 400이고 DB에 저장되지 않는다`() {
-        val (user, token) = dataGenerator.generateUserWithAccessToken()
-        val userId = requireNotNull(user.id)
-
-        val group = dataGenerator.generateCategoryGroup(name = "group", sortOrder = 1)
-        val c1 = dataGenerator.generateCategory(group = group, name = "c1", sortOrder = 1)
-        val c2 = dataGenerator.generateCategory(group = group, name = "c2", sortOrder = 2)
-
-        val id1 = c1.id!!
-        val id2 = c2.id!!
-
-        mockMvc.perform(
-            put("/api/v1/users/me/interest-categories")
-                .header("Authorization", bearer(token))
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(replaceAllBody(id1 to 1, id1 to 2, id2 to 3))
-        )
-            .andExpect(status().isBadRequest)
-
-        val rows = userInterestCategoryRepository.findAllWithCategoryByUserId(userId)
-        assertTrue(rows.isEmpty())
-    }
-
-    @Test
-    fun `PUT interest categories priority가 연속이 아니면 400이고 DB에 저장되지 않는다`() {
-        val (user, token) = dataGenerator.generateUserWithAccessToken()
-        val userId = requireNotNull(user.id)
-
-        val group = dataGenerator.generateCategoryGroup(name = "group", sortOrder = 1)
-        val c1 = dataGenerator.generateCategory(group = group, name = "c1", sortOrder = 1)
-        val c2 = dataGenerator.generateCategory(group = group, name = "c2", sortOrder = 2)
-
-        val id1 = c1.id!!
-        val id2 = c2.id!!
-
-        mockMvc.perform(
-            put("/api/v1/users/me/interest-categories")
-                .header("Authorization", bearer(token))
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(replaceAllBody(id1 to 1, id2 to 3))
-        )
-            .andExpect(status().isBadRequest)
-
-        val rows = userInterestCategoryRepository.findAllWithCategoryByUserId(userId)
-        assertTrue(rows.isEmpty())
-    }
-
-    @Test
-    fun `PUT interest categories 존재하지 않는 categoryId면 400이고 DB에 저장되지 않는다`() {
-        val (user, token) = dataGenerator.generateUserWithAccessToken()
-        val userId = requireNotNull(user.id)
-
-        val nonExistingCategoryId = 9_999_999_999L
-
-        mockMvc.perform(
-            put("/api/v1/users/me/interest-categories")
-                .header("Authorization", bearer(token))
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(replaceAllBody(nonExistingCategoryId to 1))
-        )
-            .andExpect(status().isBadRequest)
-
-        val rows = userInterestCategoryRepository.findAllWithCategoryByUserId(userId)
-        assertTrue(rows.isEmpty())
-    }
-
-    @Test
-    fun `Interest Categories API는 토큰 없으면 401이고 DB 변화가 없다`() {
-        // GET
-        mockMvc.perform(get("/api/v1/users/me/interest-categories"))
-            .andExpect(status().isUnauthorized)
-
-        // PUT
-        mockMvc.perform(
-            put("/api/v1/users/me/interest-categories")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(toJson(mapOf("items" to emptyList<Any>())))
-        )
-            .andExpect(status().isUnauthorized)
-
-        // DELETE
-        mockMvc.perform(delete("/api/v1/users/me/interest-categories/1"))
-            .andExpect(status().isUnauthorized)
-    }
-
-    // -----------------------------
-    // Excluded Keywords
-    // -----------------------------
-
-    @Test
-    fun `GET excluded-keywords - 처음엔 빈 배열`() {
-        val (_, token) = dataGenerator.generateUserWithAccessToken()
-
-        mockMvc.perform(
-            get("/api/v1/users/me/excluded-keywords")
-                .header("Authorization", bearer(token))
-        )
-            .andExpect(status().isOk)
-            .andExpect(jsonPath("$.items").isArray)
-            .andExpect(jsonPath("$.items.length()").value(0))
-    }
-
-    @Test
-    fun `POST excluded-keywords - 성공하면 201, GET에 trim된 키워드가 보인다`() {
-        val (user, token) = dataGenerator.generateUserWithAccessToken()
-
-        mockMvc.perform(
-            post("/api/v1/users/me/excluded-keywords")
-                .header("Authorization", bearer(token))
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("""{"keyword":"   apple  "}""")
-        )
-            .andExpect(status().isCreated)
-
-        // DB에도 trim된 keyword로 저장됐는지 확인
-        assertEquals(1, userExcludedKeywordRepository.countByUserIdAndKeyword(requireNotNull(user.id), "apple"))
-
-        val body = list(token)
-        assertEquals(1, body.items.size)
-        assertEquals("apple", body.items[0].keyword)
-        assertTrue(body.items[0].id > 0)
-        assertTrue(body.items[0].createdAt.isNotBlank())
-    }
-
-    @Test
-    fun `POST excluded-keywords - 같은 키워드 중복 추가해도 멱등으로 1개만 유지`() {
-        val (user, token) = dataGenerator.generateUserWithAccessToken()
-
-        mockMvc.perform(
-            post("/api/v1/users/me/excluded-keywords")
-                .header("Authorization", bearer(token))
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("""{"keyword":"banana"}""")
-        )
-            .andExpect(status().isCreated)
-
-        // 같은 키워드 재요청 (서비스가 return 처리 → 컨트롤러는 201 유지)
-        mockMvc.perform(
-            post("/api/v1/users/me/excluded-keywords")
-                .header("Authorization", bearer(token))
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("""{"keyword":"banana"}""")
-        )
-            .andExpect(status().isCreated)
-
-        // DB에 1개만 있어야 함
-        assertEquals(1, userExcludedKeywordRepository.countByUserIdAndKeyword(requireNotNull(user.id), "banana"))
-
-        val body = list(token)
-        assertEquals(1, body.items.size)
-        assertEquals("banana", body.items[0].keyword)
-    }
-
-    @Test
-    fun `POST excluded-keywords - blank면 400`() {
-        val (_, token) = dataGenerator.generateUserWithAccessToken()
-
-        // @NotBlank + 서비스 trim/blank 체크 둘 다 걸릴 수 있음
-        mockMvc.perform(
-            post("/api/v1/users/me/excluded-keywords")
-                .header("Authorization", bearer(token))
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("""{"keyword":"   "}""")
-        )
-            .andExpect(status().isBadRequest)
-    }
-
-    @Test
-    fun `GET excluded-keywords - created_at desc, id desc 정렬`() {
-        val (_, token) = dataGenerator.generateUserWithAccessToken()
-
-        // 순서대로 넣었을 때, 리스트는 최신이 먼저 와야 함
-        mockMvc.perform(
-            post("/api/v1/users/me/excluded-keywords")
-                .header("Authorization", bearer(token))
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("""{"keyword":"k1"}""")
-        ).andExpect(status().isCreated)
-
-        mockMvc.perform(
-            post("/api/v1/users/me/excluded-keywords")
-                .header("Authorization", bearer(token))
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("""{"keyword":"k2"}""")
-        ).andExpect(status().isCreated)
-
-        mockMvc.perform(
-            post("/api/v1/users/me/excluded-keywords")
-                .header("Authorization", bearer(token))
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("""{"keyword":"k3"}""")
-        ).andExpect(status().isCreated)
-
-        val body = list(token)
-        assertEquals(listOf("k3", "k2", "k1"), body.items.map { it.keyword })
-    }
-
-    @Test
-    fun `DELETE excluded-keywords - 내 키워드 삭제되면 204, GET에서 제거됨`() {
-        val (_, token) = dataGenerator.generateUserWithAccessToken()
-
-        // 추가
-        mockMvc.perform(
-            post("/api/v1/users/me/excluded-keywords")
-                .header("Authorization", bearer(token))
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("""{"keyword":"to-delete"}""")
-        )
-            .andExpect(status().isCreated)
-
-        val before = list(token)
-        assertEquals(1, before.items.size)
-        val id = before.items[0].id
-
-        // 삭제
-        mockMvc.perform(
-            delete("/api/v1/users/me/excluded-keywords/$id")
-                .header("Authorization", bearer(token))
-        )
-            .andExpect(status().isNoContent)
-
-        val after = list(token)
-        assertEquals(0, after.items.size)
-    }
-
-    @Test
-    fun `DELETE excluded-keywords - 남의 id로 삭제 시도하면 400`() {
-        val (_, tokenA) = dataGenerator.generateUserWithAccessToken()
-        val (_, tokenB) = dataGenerator.generateUserWithAccessToken()
-
-        // A가 키워드 추가
-        mockMvc.perform(
-            post("/api/v1/users/me/excluded-keywords")
-                .header("Authorization", bearer(tokenA))
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("""{"keyword":"secret"}""")
-        )
-            .andExpect(status().isCreated)
-
-        val aList = list(tokenA)
-        val aId = aList.items.single().id
-
-        // B가 A의 excludedKeywordId로 삭제 시도
-        mockMvc.perform(
-            delete("/api/v1/users/me/excluded-keywords/$aId")
-                .header("Authorization", bearer(tokenB))
-        )
-            .andExpect(status().isBadRequest)
-
-        // A의 목록은 그대로 남아야 함
-        val aAfter = list(tokenA)
-        assertEquals(1, aAfter.items.size)
-        assertEquals("secret", aAfter.items[0].keyword)
-    }
-
-    @Test
-    fun `DELETE excluded-keywords - 존재하지 않는 id 삭제 시 400`() {
-        val (_, token) = dataGenerator.generateUserWithAccessToken()
-
-        mockMvc.perform(
-            delete("/api/v1/users/me/excluded-keywords/999999999")
-                .header("Authorization", bearer(token))
-        )
-            .andExpect(status().isBadRequest)
-    }
-
-    @Test
-    fun `ExcludedKeyword API - 인증 없으면 401`() {
-        mockMvc.perform(get("/api/v1/users/me/excluded-keywords"))
-            .andExpect(status().isUnauthorized)
-
-        mockMvc.perform(
-            post("/api/v1/users/me/excluded-keywords")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("""{"keyword":"x"}""")
-        )
-            .andExpect(status().isUnauthorized)
-
-        mockMvc.perform(delete("/api/v1/users/me/excluded-keywords/1"))
-            .andExpect(status().isUnauthorized)
+    fun `interest categories는 인증이 필요하다`() {
+        mockMvc.perform(get("/api/v1/users/me/interest-categories")).andExpect(status().isUnauthorized)
+        mockMvc.perform(put("/api/v1/users/me/interest-categories").contentType(MediaType.APPLICATION_JSON)
+            .content(toJson(mapOf("items" to emptyList<Any>())))).andExpect(status().isUnauthorized)
     }
 }

--- a/hangsha/src/test/kotlin/com/team1/hangsha/helper/DataGenerator.kt
+++ b/hangsha/src/test/kotlin/com/team1/hangsha/helper/DataGenerator.kt
@@ -2,6 +2,7 @@ package com.team1.hangsha.helper
 
 import com.team1.hangsha.category.model.Category
 import com.team1.hangsha.category.model.CategoryGroup
+import com.team1.hangsha.category.model.Organization
 import com.team1.hangsha.common.enums.CourseSource
 import com.team1.hangsha.common.enums.DayOfWeek
 import com.team1.hangsha.common.enums.Semester
@@ -21,6 +22,7 @@ import com.team1.hangsha.user.model.UserIdentity
 import com.team1.hangsha.user.model.UserInterestCategory
 import com.team1.hangsha.category.repository.CategoryGroupRepository
 import com.team1.hangsha.category.repository.CategoryRepository
+import com.team1.hangsha.category.repository.OrganizationRepository
 import com.team1.hangsha.course.repository.CourseRepository
 import com.team1.hangsha.course.repository.CourseTimeSlotRepository
 import com.team1.hangsha.event.repository.EventRepository
@@ -30,6 +32,8 @@ import com.team1.hangsha.timetable.repository.EnrollRepository
 import com.team1.hangsha.timetable.repository.TimetableRepository
 import com.team1.hangsha.user.repository.UserIdentityRepository
 import com.team1.hangsha.user.repository.UserInterestCategoryRepository
+import com.team1.hangsha.user.repository.UserInterestDomainRepository
+import com.team1.hangsha.user.model.InterestCategoryType
 import com.team1.hangsha.user.repository.UserRepository
 import org.mindrot.jbcrypt.BCrypt
 import org.springframework.stereotype.Component
@@ -42,10 +46,12 @@ class DataGenerator(
     private val userRepository: UserRepository,
     private val userIdentityRepository: UserIdentityRepository,
     private val userInterestCategoryRepository: UserInterestCategoryRepository,
+    private val userInterestDomainRepository: UserInterestDomainRepository,
     private val jwtTokenProvider: JwtTokenProvider,
 
     private val categoryGroupRepository: CategoryGroupRepository,
     private val categoryRepository: CategoryRepository,
+    private val organizationRepository: OrganizationRepository,
 
     private val eventRepository: EventRepository,
 
@@ -176,9 +182,9 @@ class DataGenerator(
      * orgId 필터용 카테고리 필요할 때 사용.
      * repo에 findByName이 없을 수 있으니 "그냥 새 그룹을 만들어도 테스트는 충분"하게 설계.
      */
-    fun generateOrgCategory(name: String? = null): Category {
-        val orgGroup = generateCategoryGroup(name = "주체기관", sortOrder = 1)
-        return generateCategory(group = orgGroup, name = name)
+    fun generateOrgCategory(name: String? = null): Organization {
+        val n = next()
+        return organizationRepository.save(Organization(name = name ?: "organization-$n", sortOrder = n.toInt()))
     }
 
     // ----------------------------
@@ -197,6 +203,10 @@ class DataGenerator(
                 priority = priority,
             ),
         )
+    }
+
+    fun addUserInterestCategory(user: User, organization: Organization, priority: Int = 1) {
+        userInterestDomainRepository.add(user.id!!, InterestCategoryType.ORGANIZATION, organization.id!!, priority)
     }
 
     /**


### PR DESCRIPTION
### 1. 카테고리 조회 API 변경

  기존 API는 제거됩니다.

  - GET /api/v1/category-groups/with-categories
  - GET /api/v1/categories/orgs

  대신 아래 API를 사용해주세요.

   용도             새 API
  ━━━━━━━━━━━━━━━  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   행사 상태        GET /api/v1/event-statuses
  ───────────────  ────────────────────────────
   프로그램 유형    GET /api/v1/event-types
  ───────────────  ────────────────────────────
   주체기관         GET /api/v1/organizations

  응답 형식은 동일하게 간단한 목록입니다.

  {
    "items": [
      {
        "id": 1,
        "name": "모집중",
        "sortOrder": 2
      }
    ]
  }

  organizations는 기존처럼 실제 행사에 2회 이상 연결된 기관만 반환합니다.

  ### 2. 이벤트 필터/응답의 ID 의미 변경

  이벤트 API의 query parameter와 응답 필드명은 유지됩니다.

  - statusId
  - eventTypeId
  - orgId

  다만 각 ID는 더 이상 공용 categories.id가 아닙니다.

   필드           참조할 목록 API
  ━━━━━━━━━━━━━  ━━━━━━━━━━━━━━━━━
   statusId       /event-statuses
  ─────────────  ─────────────────
   eventTypeId    /event-types
  ─────────────  ─────────────────
   orgId          /organizations

  즉 필터 UI는 각 새 목록 API에서 받은 ID만 이벤트 조회에 전달해야 합니다.

  ### 3. 관심 카테고리 API 요청 형식 변경

  GET/PUT /api/v1/users/me/interest-categories는 유지되지만, ID 충돌 방지를 위해 categoryType이 추가됩니다.

  기존:

  {
    "items": [
      { "categoryId": 12, "priority": 1 }
    ]
  }

  변경:

  {
    "items": [
      {
        "categoryType": "ORGANIZATION",
        "categoryId": 12,
        "priority": 1
      }
    ]
  }

  categoryType 값:

  - EVENT_STATUS
  - EVENT_TYPE
  - ORGANIZATION

  조회 응답도 기존의 중첩 category 객체 대신 아래처럼 변경됩니다.

  {
    "items": [
      {
        "categoryType": "ORGANIZATION",
        "categoryId": 12,
        "name": "학생처",
        "sortOrder": 1,
        "priority": 1
      }
    ]
  }

  ### 4. 관심 카테고리 삭제 API 변경

  기존:

  DELETE /api/v1/users/me/interest-categories/{categoryId}

  변경:

  DELETE /api/v1/users/me/interest-categories/{categoryId}?categoryType=ORGANIZATION

  categoryType은 필수입니다.