### PR TITLE
feat: 행사 목록 조회 시 비로그인 유저도 키워드 제외 가능 지원

### DIFF
--- a/hangsha/src/main/kotlin/com/team1/hangsha/event/controller/EventController.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/event/controller/EventController.kt
@@ -33,6 +33,7 @@ class EventController(
         @RequestParam("eventTypeId", required = false) eventTypeIds: List<Long>?,
         @RequestParam("orgId", required = false) orgIds: List<Long>?,
         @RequestParam("applyExcludedKeywords", defaultValue = "true") applyExcludedKeywords: Boolean,
+        @RequestParam("excludedKeyword", required = false) excludedKeywords: List<String>?,
     ): MonthEventResponse =
         eventService.getMonthEvents(
             from = from,
@@ -42,6 +43,7 @@ class EventController(
             orgIds = orgIds,
             userId = user?.id,
             applyExcludedKeywords = applyExcludedKeywords,
+            excludedKeywords = excludedKeywords,
         )
 
     @GetMapping("/count")
@@ -81,6 +83,7 @@ class EventController(
         @RequestParam("eventTypeId", required = false) eventTypeIds: List<Long>?,
         @RequestParam("orgId", required = false) orgIds: List<Long>?,
         @RequestParam("applyExcludedKeywords", defaultValue = "true") applyExcludedKeywords: Boolean,
+        @RequestParam("excludedKeyword", required = false) excludedKeywords: List<String>?,
     ): DayEventResponse =
         eventService.getDayEvents(
             date = date,
@@ -91,6 +94,7 @@ class EventController(
             orgIds = orgIds,
             userId = user?.id,
             applyExcludedKeywords = applyExcludedKeywords,
+            excludedKeywords = excludedKeywords,
         )
 
     @GetMapping("/search")

--- a/hangsha/src/main/kotlin/com/team1/hangsha/event/repository/EventQueryRepository.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/event/repository/EventQueryRepository.kt
@@ -21,6 +21,7 @@ class EventQueryRepository(
         orgIds: List<Long>?,
         userId: Long?,
         applyExcludedKeywords: Boolean = true,
+        excludedKeywords: List<String> = emptyList(),
     ): List<Event> {
         val sql = buildString {
             append(
@@ -51,7 +52,7 @@ class EventQueryRepository(
             if (!orgIds.isNullOrEmpty()) append("\n  AND org_id IN (:orgIds)")
 
             if (applyExcludedKeywords) {
-                appendExcludedKeywordsFilter(userId)
+                appendExcludedKeywordsFilter(userId, excludedKeywords)
             }
 
             appendEventOrderBy(userId)
@@ -65,6 +66,7 @@ class EventQueryRepository(
         if (!eventTypeIds.isNullOrEmpty()) params["eventTypeIds"] = eventTypeIds
         if (!orgIds.isNullOrEmpty()) params["orgIds"] = orgIds
         if (userId != null) params["userId"] = userId
+        excludedKeywords.forEachIndexed { index, keyword -> params["excludedKeyword$index"] = keyword }
 
         return jdbc.query(sql, params) { rs, _ -> rs.toEvent() }
     }
@@ -106,7 +108,7 @@ class EventQueryRepository(
             if (!eventTypeIds.isNullOrEmpty()) append("\n  AND event_type_id IN (:eventTypeIds)")
             if (!orgIds.isNullOrEmpty()) append("\n  AND org_id IN (:orgIds)")
             if (applyExcludedKeywords) {
-                appendExcludedKeywordsFilter(userId)
+                appendExcludedKeywordsFilter(userId, emptyList())
             }
         }
 
@@ -129,6 +131,7 @@ class EventQueryRepository(
         orgIds: List<Long>?,
         userId: Long?,
         applyExcludedKeywords: Boolean = true,
+        excludedKeywords: List<String> = emptyList(),
     ): Int {
         val dayStart = date.atStartOfDay()
         val dayEndExclusive = date.plusDays(1).atStartOfDay()
@@ -161,7 +164,7 @@ class EventQueryRepository(
             if (!orgIds.isNullOrEmpty()) append("\n  AND org_id IN (:orgIds)")
 
             if (applyExcludedKeywords) {
-                appendExcludedKeywordsFilter(userId)
+                appendExcludedKeywordsFilter(userId, excludedKeywords)
             }
         }
 
@@ -173,6 +176,7 @@ class EventQueryRepository(
         if (!eventTypeIds.isNullOrEmpty()) params["eventTypeIds"] = eventTypeIds
         if (!orgIds.isNullOrEmpty()) params["orgIds"] = orgIds
         if (userId != null) params["userId"] = userId
+        excludedKeywords.forEachIndexed { index, keyword -> params["excludedKeyword$index"] = keyword }
 
         return jdbc.queryForObject(sql, params, Int::class.java) ?: 0
     }
@@ -186,6 +190,7 @@ class EventQueryRepository(
         size: Int,
         userId: Long?,
         applyExcludedKeywords: Boolean = true,
+        excludedKeywords: List<String> = emptyList(),
     ): List<Event> {
         val safePage = max(1, page)
         val safeSize = max(1, size)
@@ -222,7 +227,7 @@ class EventQueryRepository(
             if (!orgIds.isNullOrEmpty()) append("\n  AND org_id IN (:orgIds)")
 
             if (applyExcludedKeywords) {
-                appendExcludedKeywordsFilter(userId)
+                appendExcludedKeywordsFilter(userId, excludedKeywords)
             }
 
             appendEventOrderBy(userId)
@@ -239,6 +244,7 @@ class EventQueryRepository(
         if (!eventTypeIds.isNullOrEmpty()) params["eventTypeIds"] = eventTypeIds
         if (!orgIds.isNullOrEmpty()) params["orgIds"] = orgIds
         if (userId != null) params["userId"] = userId
+        excludedKeywords.forEachIndexed { index, keyword -> params["excludedKeyword$index"] = keyword }
 
         return jdbc.query(sql, params) { rs, _ -> rs.toEvent() }
     }
@@ -316,8 +322,18 @@ private fun ResultSet.toEvent(): Event {
     )
 }
 
-private fun StringBuilder.appendExcludedKeywordsFilter(userId: Long?) {
-    if (userId == null) return
+private fun StringBuilder.appendExcludedKeywordsFilter(userId: Long?, excludedKeywords: List<String>) {
+    if (userId == null) {
+        if (excludedKeywords.isEmpty()) return
+        append("\n  AND NOT (")
+        append(
+            excludedKeywords.indices.joinToString(" OR ") { index ->
+                "LOWER(e.title) LIKE CONCAT('%', :excludedKeyword$index, '%')"
+            }
+        )
+        append(")")
+        return
+    }
 
     append(
         """

--- a/hangsha/src/main/kotlin/com/team1/hangsha/event/repository/EventQueryRepository.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/event/repository/EventQueryRepository.kt
@@ -328,7 +328,7 @@ private fun StringBuilder.appendExcludedKeywordsFilter(userId: Long?, excludedKe
         append("\n  AND NOT (")
         append(
             excludedKeywords.indices.joinToString(" OR ") { index ->
-                "LOWER(e.title) LIKE CONCAT('%', :excludedKeyword$index, '%')"
+                "LOWER(e.title) LIKE CONCAT('%', :excludedKeyword$index, '%') ESCAPE '!'"
             }
         )
         append(")")

--- a/hangsha/src/main/kotlin/com/team1/hangsha/event/service/EventService.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/event/service/EventService.kt
@@ -42,6 +42,7 @@ class EventService(
         orgIds: List<Long>?,
         userId: Long?,
         applyExcludedKeywords: Boolean = true,
+        excludedKeywords: List<String>? = null,
     ): MonthEventResponse {
         if (from.isAfter(to)) {
             throw DomainException(ErrorCode.INVALID_REQUEST, "from은 to보다 이후일 수 없습니다")
@@ -58,6 +59,7 @@ class EventService(
             orgIds = orgIds,
             userId = userId,
             applyExcludedKeywords = applyExcludedKeywords,
+            excludedKeywords = explicitExcludedKeywords(userId, applyExcludedKeywords, excludedKeywords),
         )
 
         val interestPriorities = loadInterestPriorities(userId)
@@ -177,12 +179,14 @@ class EventService(
         orgIds: List<Long>?,
         userId: Long?,
         applyExcludedKeywords: Boolean = true,
+        excludedKeywords: List<String>? = null,
     ): DayEventResponse {
+        val explicitExcludedKeywords = explicitExcludedKeywords(userId, applyExcludedKeywords, excludedKeywords)
         val total = eventQueryRepository.countOnDay(
-            date, statusIds, eventTypeIds, orgIds, userId, applyExcludedKeywords
+            date, statusIds, eventTypeIds, orgIds, userId, applyExcludedKeywords, explicitExcludedKeywords
         )
         val events = eventQueryRepository.findOnDayPaged(
-            date, statusIds, eventTypeIds, orgIds, page, size, userId, applyExcludedKeywords
+            date, statusIds, eventTypeIds, orgIds, page, size, userId, applyExcludedKeywords, explicitExcludedKeywords
         )
 
         val interestPriorities = loadInterestPriorities(userId)
@@ -339,6 +343,19 @@ class EventService(
             }
         }
     }
+
+    private fun explicitExcludedKeywords(
+        userId: Long?,
+        applyExcludedKeywords: Boolean,
+        excludedKeywords: List<String>?,
+    ): List<String> =
+        if (userId != null || !applyExcludedKeywords) emptyList()
+        else excludedKeywords.orEmpty()
+            .asSequence()
+            .map { it.trim().lowercase() }
+            .filter { it.isNotBlank() }
+            .distinct()
+            .toList()
 }
 
 private data class InterestPriorities(

--- a/hangsha/src/main/kotlin/com/team1/hangsha/event/service/EventService.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/event/service/EventService.kt
@@ -355,7 +355,11 @@ class EventService(
             .map { it.trim().lowercase() }
             .filter { it.isNotBlank() }
             .distinct()
+            .map(::escapeLikeKeyword)
             .toList()
+
+    private fun escapeLikeKeyword(keyword: String): String =
+        keyword.replace("!", "!!").replace("%", "!%").replace("_", "!_")
 }
 
 private data class InterestPriorities(

--- a/hangsha/src/main/resources/static/openapi.yaml
+++ b/hangsha/src/main/resources/static/openapi.yaml
@@ -1210,6 +1210,15 @@ paths:
             items: { type: integer, format: int64 }
           style: form
           explode: true
+        - in: query
+          name: excludedKeyword
+          required: false
+          description: 비로그인 사용자의 제외 키워드입니다. 같은 파라미터를 반복해 여러 개를 전달할 수 있습니다.
+          schema:
+            type: array
+            items: { type: string }
+          style: form
+          explode: true
 
       responses:
         "200":
@@ -1266,6 +1275,15 @@ paths:
           schema:
             type: array
             items: { type: integer, format: int64 }
+          style: form
+          explode: true
+        - in: query
+          name: excludedKeyword
+          required: false
+          description: 비로그인 사용자의 제외 키워드입니다. 같은 파라미터를 반복해 여러 개를 전달할 수 있습니다.
+          schema:
+            type: array
+            items: { type: string }
           style: form
           explode: true
 


### PR DESCRIPTION
호출 예시:

  GET /api/v1/events/day?date=2026-08-22&excludedKeyword=동아리&excludedKeyword=특강