### PR TITLE
  feat: Sign in with Apple 인증 및 계정 연동 지원

### DIFF
--- a/hangsha/src/main/kotlin/com/team1/hangsha/auth/dto/AuthDto.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/auth/dto/AuthDto.kt
@@ -4,9 +4,13 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class SocialLoginRequest(
     val provider: String,
-    val code: String?, // web 필수, mobile null
-    val accessToken: String?, // web null, mobile 필수
-    val codeVerifier: String?, // 구글 PKCE용
+    val code: String? = null, // web 필수, mobile null
+    val accessToken: String? = null, // web null, mobile 필수
+    val identityToken: String? = null, // Apple native identity JWT
+    val userIdentifier: String? = null, // Apple native credential.user (verified against JWT sub)
+    val email: String? = null, // Apple가 최초 승인에서만 제공할 수 있는 참고값
+    val name: String? = null, // Apple가 최초 승인에서만 제공할 수 있는 이름
+    val codeVerifier: String? = null, // 구글 PKCE용
     @JsonProperty("client_type")
     val clientType: String? = "WEB"
 )

--- a/hangsha/src/main/kotlin/com/team1/hangsha/auth/service/AppleIdentityTokenVerifier.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/auth/service/AppleIdentityTokenVerifier.kt
@@ -1,0 +1,91 @@
+package com.team1.hangsha.auth.service
+
+import com.team1.hangsha.common.error.DomainException
+import com.team1.hangsha.common.error.ErrorCode
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator
+import org.springframework.security.oauth2.core.OAuth2Error
+import org.springframework.security.oauth2.core.OAuth2TokenValidator
+import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.jwt.JwtException
+import org.springframework.security.oauth2.jwt.JwtValidators
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder
+import org.springframework.stereotype.Service
+
+data class AppleIdentity(
+    val providerUserId: String,
+    val email: String?,
+)
+
+interface AppleIdentityTokenVerifier {
+    fun verify(identityToken: String): AppleIdentity
+}
+
+@Service
+class NimbusAppleIdentityTokenVerifier(
+    @Value("\${auth.apple.allowed-client-ids}") allowedClientIdsValue: String,
+) : AppleIdentityTokenVerifier {
+    private val allowedClientIds = allowedClientIdsValue
+        .split(',')
+        .map(String::trim)
+        .filter(String::isNotEmpty)
+        .toSet()
+
+    private val decoder = NimbusJwtDecoder.withJwkSetUri(APPLE_JWK_SET_URI).build().apply {
+        val audienceValidator = OAuth2TokenValidator<Jwt> { jwt ->
+            if (jwt.audience.any(allowedClientIds::contains)) {
+                OAuth2TokenValidatorResult.success()
+            } else {
+                OAuth2TokenValidatorResult.failure(
+                    OAuth2Error("invalid_token", "Apple identity token audience가 올바르지 않습니다.", null),
+                )
+            }
+        }
+        setJwtValidator(
+            DelegatingOAuth2TokenValidator(
+                JwtValidators.createDefaultWithIssuer(APPLE_ISSUER),
+                audienceValidator,
+            ),
+        )
+    }
+
+    init {
+        require(allowedClientIds.isNotEmpty()) { "auth.apple.allowed-client-ids must not be empty." }
+    }
+
+    override fun verify(identityToken: String): AppleIdentity {
+        val jwt = try {
+            decoder.decode(identityToken)
+        } catch (error: JwtException) {
+            throw DomainException(
+                ErrorCode.AUTH_INVALID_CREDENTIALS,
+                "유효하지 않은 Apple identity token입니다.",
+                error,
+            )
+        }
+
+        val providerUserId = jwt.subject?.trim().orEmpty()
+        if (providerUserId.isEmpty()) {
+            throw DomainException(ErrorCode.AUTH_INVALID_CREDENTIALS, "Apple 사용자 식별자가 없습니다.")
+        }
+
+        val email = jwt.getClaimAsString("email")?.trim()?.lowercase()?.takeIf { it.isNotEmpty() }
+        if (email != null && !isEmailVerified(jwt.claims["email_verified"])) {
+            throw DomainException(ErrorCode.AUTH_INVALID_CREDENTIALS, "Apple 이메일이 검증되지 않았습니다.")
+        }
+
+        return AppleIdentity(providerUserId = providerUserId, email = email)
+    }
+
+    private fun isEmailVerified(claim: Any?): Boolean = when (claim) {
+        is Boolean -> claim
+        is String -> claim.equals("true", ignoreCase = true)
+        else -> false
+    }
+
+    private companion object {
+        const val APPLE_ISSUER = "https://appleid.apple.com"
+        const val APPLE_JWK_SET_URI = "https://appleid.apple.com/auth/keys"
+    }
+}

--- a/hangsha/src/main/kotlin/com/team1/hangsha/auth/service/AuthService.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/auth/service/AuthService.kt
@@ -7,6 +7,9 @@ import com.team1.hangsha.common.error.DomainException
 import com.team1.hangsha.common.error.ErrorCode
 import com.team1.hangsha.common.extentions.truncateByDisplayLength
 import com.team1.hangsha.user.model.User
+import com.team1.hangsha.user.model.AuthProvider
+import com.team1.hangsha.user.model.UserIdentity
+import com.team1.hangsha.user.repository.UserIdentityRepository
 import com.team1.hangsha.user.repository.UserRepository
 import com.team1.hangsha.user.service.UserService
 import org.springframework.beans.factory.annotation.Value
@@ -22,7 +25,9 @@ import org.springframework.web.client.RestTemplate
 @Service
 class AuthService(
     private val userRepository: UserRepository,
+    private val userIdentityRepository: UserIdentityRepository,
     private val userService: UserService,
+    private val appleIdentityTokenVerifier: AppleIdentityTokenVerifier,
 
     @Value("\${spring.security.oauth2.client.registration.google.client-id}") val googleClientId: String,
     @Value("\${spring.security.oauth2.client.registration.google.client-secret}") val googleClientSecret: String,
@@ -41,6 +46,10 @@ class AuthService(
 
     @Transactional
     fun socialLogin(req: SocialLoginRequest): SocialLoginResult {
+        if (req.provider.equals("APPLE", ignoreCase = true)) {
+            return appleLogin(req)
+        }
+
         val socialProfile = when (req.provider.uppercase()) {
             "GOOGLE" -> getGoogleProfile(req.code,req.accessToken, req.codeVerifier, req.clientType) // codeVerifier 추가된 버전 유지
             "KAKAO" -> getKakaoProfile(req.code, req.accessToken)
@@ -70,6 +79,66 @@ class AuthService(
             accessToken = issued.accessToken,
             refreshCookie = issued.refreshCookie,
             isNewUser = isNewUser
+        )
+    }
+
+    private fun appleLogin(req: SocialLoginRequest): SocialLoginResult {
+        val identityToken = req.identityToken?.takeIf { it.isNotBlank() }
+            ?: throw DomainException(ErrorCode.AUTH_INVALID_CREDENTIALS, "Apple identity token이 없습니다.")
+        val appleIdentity = appleIdentityTokenVerifier.verify(identityToken)
+
+        if (
+            !req.userIdentifier.isNullOrBlank() &&
+            req.userIdentifier != appleIdentity.providerUserId
+        ) {
+            throw DomainException(ErrorCode.AUTH_INVALID_CREDENTIALS, "Apple 사용자 식별자가 일치하지 않습니다.")
+        }
+
+        val existingIdentity = userIdentityRepository.findByProviderAndProviderUserId(
+            AuthProvider.APPLE,
+            appleIdentity.providerUserId,
+        )
+
+        var isNewUser = false
+        val user = if (existingIdentity != null) {
+            userRepository.findById(existingIdentity.userId)
+                .orElseThrow { DomainException(ErrorCode.USER_NOT_FOUND) }
+        } else {
+            val verifiedEmail = appleIdentity.email
+                ?: throw DomainException(
+                    ErrorCode.AUTH_INVALID_CREDENTIALS,
+                    "신규 Apple 계정의 검증된 이메일 정보가 없습니다.",
+                )
+            val existingUser = userRepository.findByEmail(verifiedEmail)
+            val linkedUser = existingUser ?: run {
+                isNewUser = true
+                val requestedName = req.name?.trim()?.takeIf { it.isNotBlank() }
+                val username = (requestedName ?: verifiedEmail.substringBefore("@"))
+                    .truncateByDisplayLength(20)
+                userRepository.save(
+                    User(
+                        email = verifiedEmail,
+                        username = username,
+                    ),
+                )
+            }
+
+            userIdentityRepository.save(
+                UserIdentity(
+                    userId = linkedUser.id!!,
+                    provider = AuthProvider.APPLE,
+                    providerUserId = appleIdentity.providerUserId,
+                    email = verifiedEmail,
+                ),
+            )
+            linkedUser
+        }
+
+        val issued = userService.issueAfterSocialLogin(user.id!!)
+        return SocialLoginResult(
+            accessToken = issued.accessToken,
+            refreshCookie = issued.refreshCookie,
+            isNewUser = isNewUser,
         )
     }
 

--- a/hangsha/src/main/kotlin/com/team1/hangsha/user/model/AuthProvider.kt
+++ b/hangsha/src/main/kotlin/com/team1/hangsha/user/model/AuthProvider.kt
@@ -1,5 +1,5 @@
 package com.team1.hangsha.user.model
 
 enum class AuthProvider {
-    LOCAL, GOOGLE, KAKAO, NAVER
+    LOCAL, APPLE, GOOGLE, KAKAO, NAVER
 }

--- a/hangsha/src/main/resources/application.yml
+++ b/hangsha/src/main/resources/application.yml
@@ -100,6 +100,11 @@ email:
     code-length: 6
     signup-token-ttl: 30m
 
+auth:
+  apple:
+    # Apple identity token의 aud에 허용할 iOS bundle identifier 목록 (쉼표 구분)
+    allowed-client-ids: ${APPLE_CLIENT_IDS:com.wafflestudio.hangsha.dev,com.wafflestudio.hangsha}
+
 search:
   reindex:
     enabled: true

--- a/hangsha/src/main/resources/static/openapi.yaml
+++ b/hangsha/src/main/resources/static/openapi.yaml
@@ -124,15 +124,36 @@ components:
 
     SocialLoginRequest:
       type: object
-      required: [ provider, code ]
+      required: [ provider ]
       properties:
         provider:
           type: string
           description: 소셜 로그인 Provider
-          enum: [ GOOGLE, KAKAO, NAVER ]
+          enum: [ APPLE, GOOGLE, KAKAO, NAVER ]
         code:
           type: string
+          nullable: true
           description: OAuth Authorization Code
+        accessToken:
+          type: string
+          nullable: true
+          description: Google/Kakao/Naver 모바일 access token
+        identityToken:
+          type: string
+          nullable: true
+          description: Apple 네이티브 로그인에서 받은 identity JWT
+        userIdentifier:
+          type: string
+          nullable: true
+          description: Apple credential user identifier (서버에서 JWT sub와 대조)
+        email:
+          type: string
+          nullable: true
+          description: Apple가 최초 승인에서 반환한 이메일 참고값 (계정 식별에는 검증된 JWT claim 사용)
+        name:
+          type: string
+          nullable: true
+          description: Apple가 최초 승인에서 반환한 사용자 이름
         codeVerifier:
           type: string
           nullable: true
@@ -934,6 +955,15 @@ paths:
                   provider: NAVER
                   code: "authorization_code_here"
                   codeVerifier: null
+              apple:
+                summary: Apple (iOS native)
+                value:
+                  provider: APPLE
+                  identityToken: "apple.identity.jwt"
+                  userIdentifier: "apple-user-identifier"
+                  name: "홍길동"
+                  code: "short-lived-authorization-code"
+                  client_type: MOB
       responses:
         "200":
           description: 로그인 성공 (accessToken 반환 + refreshToken 쿠키 세팅)


### PR DESCRIPTION
  ## 배경

  App Store Review Guideline 4.8 대응을 위해 기존 소셜 로그인과 동등한
  Sign in with Apple 인증을 지원합니다.

  ## 주요 변경사항
  - 소셜 로그인 provider에 `APPLE` 추가
  - iOS 네이티브 앱에서 전달한 Apple identity token 검증
  - Apple 공개 JWK를 이용한 JWT 서명 검증
  - 토큰 issuer이 애플이 맞는지, 아직 유효한지, 행샤 앱을 위한 토큰이 맞는지 검증
  - ios native sdk가 반환한 Apple credential user identifier와 Apple identity token의 JWT subject 일치 검증
  - `APPLE + providerUserId` 기반 기존 사용자 조회
  - 검증된 Apple 이메일을 이용한 기존 계정 연결 또는 신규 계정 생성
  - Hide My Email relay 주소 지원
  - 기존 access/refresh token 및 mobile session 발급 구조 재사용
  - OpenAPI의 Apple 소셜 로그인 요청 스키마 추가

  ## 인증 흐름
  1. iOS 앱이 Sign in with Apple을 실행합니다.
  2. 앱이 identity token, authorization code, user identifier와 최초 제공 정보를 서버에 전달합니다.
  3. 서버가 Apple JWK로 identity token을 검증합니다.
  4. 기존 `APPLE + subject` identity가 있으면 기존 사용자로 로그인합니다.
  5. identity가 없으면 검증된 이메일로 기존 계정을 연결하거나 신규 계정을 생성합니
  다.
  6. 기존 행샤 세션과 refresh token을 발급합니다.

  클라이언트가 전달한 email은 계정 검증에 신뢰하지 않으며, Apple이 서명한 identity token의 email claim만 사용합니다.

  ## 환경 설정

  다음 환경변수가 필요합니다.

  `APPLE_CLIENT_IDS`

  쉼표로 구분된 허용 App ID 목록입니다.
  `com.wafflestudio.hangsha.dev,com.wafflestudio.hangsha`
  
  ## 후속 작업

시간되실때 Apple 계정 탈퇴 시 Apple authorization까지 자동 revoke하기 위한 후속 작업 진행해주시면 감사하겠습니다! (Apple 계정으로 가입한 사용자가 회원 탈퇴할 때 Apple authorization까지 자동으로 해제하기 위한 후속 작업)

-> iOS 앱에서 Apple 로그인 성공 시 `authorizationCode`를 서버에 전달함. 해당 코드를 Apple token endpoint ( `POST https://appleid.apple.com/auth/token`)에서 교환해 refresh token을 확보해야 함.

1. Credentials 설정 :
* Apple Developer Portal에서 Sign in with Apple private key를 발급하고 다음 값을 서버의 OCI Vault 혹은 동등한 secret storage에 등록 (작업 시 언급 주시면 값 DM으로 전달드리겠습니다)
  - `APPLE_TEAM_ID`
  - `APPLE_KEY_ID`
  - `APPLE_PRIVATE_KEY`
  - `APPLE_CLIENT_IDS`
    - `com.wafflestudio.hangsha.dev`
    - `com.wafflestudio.hangsha`
  
2. authorization code 교환 :
위에서 언급한 iOS 앱에서 전달받은 `authorizationCode`를 Apple `/auth/token`에 전달해야 합니다.
* 요청 예시 :
```
  client_id=<identity token의 검증된 audience - ex. hangsha-dev, hangsha>
  client_secret=<서버가 생성한 Apple client-secret JWT>
  code=<iOS 앱이 전달한 authorization code>
  grant_type=authorization_code
```
* 성공 응답 properties :
  - access_token
  - refresh_token
  - id_token
  - expires_in
  - token_type

3. Apple refresh token 암호화 저장
회원 탈퇴 시 Apple revoke endpoint에 refresh token을 전달하려면 원문을 저장해야 하기 때문에 해시만 저장할 수 없어서, 별도 credential 테이블 추가를 권장한다고 (코덱스에서) 합니다

  예시:
```
  apple_credentials
  - id
  - user_identity_id
  - client_id
  - encrypted_refresh_token
  - encryption_key_version
  - created_at
  - updated_at
```
4. 기존 Apple 사용자 backfill
해당 후속 기능 배포 후 Apple 사용자가 다시 로그인하면 새 auth code를 교환해 refresh token을 저장하는 것이 필요합니다.

5. 회원 탈퇴 시 Apple revoke
* Apple credential이 있는 사용자가 회원 탈퇴하면 다음 endpoint를 호출합니다. `  POST https://appleid.apple.com/auth/revoke`

* 요청 예시:
```
  client_id=<credential 저장 시 사용한 App ID>
  client_secret=<서버가 생성한 Apple client-secret JWT>
  token=<복호화한 Apple refresh token>
  token_type_hint=refresh_token
  ```
  